### PR TITLE
Added cursor lock support

### DIFF
--- a/Fullscreenizer/AllApps.Designer.cs
+++ b/Fullscreenizer/AllApps.Designer.cs
@@ -40,7 +40,7 @@
 			// lv_apps
 			// 
 			this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.ch_title});
+			this.ch_title});
 			this.lv_apps.FullRowSelect = true;
 			this.lv_apps.GridLines = true;
 			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;

--- a/Fullscreenizer/AllApps.Designer.cs
+++ b/Fullscreenizer/AllApps.Designer.cs
@@ -44,8 +44,8 @@
 			this.lv_apps.FullRowSelect = true;
 			this.lv_apps.GridLines = true;
 			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+			this.lv_apps.HideSelection = false;
 			this.lv_apps.Location = new System.Drawing.Point(6, 14);
-			this.lv_apps.MultiSelect = false;
 			this.lv_apps.Name = "lv_apps";
 			this.lv_apps.Size = new System.Drawing.Size(328, 180);
 			this.lv_apps.Sorting = System.Windows.Forms.SortOrder.Ascending;

--- a/Fullscreenizer/AllApps.Designer.cs
+++ b/Fullscreenizer/AllApps.Designer.cs
@@ -40,7 +40,7 @@
 			// lv_apps
 			// 
 			this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-			this.ch_title});
+            this.ch_title});
 			this.lv_apps.FullRowSelect = true;
 			this.lv_apps.GridLines = true;
 			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
@@ -53,6 +53,7 @@
 			this.lv_apps.TabStop = false;
 			this.lv_apps.UseCompatibleStateImageBehavior = false;
 			this.lv_apps.View = System.Windows.Forms.View.Details;
+			this.lv_apps.DoubleClick += new System.EventHandler(this.lv_apps_DoubleClick);
 			// 
 			// ch_title
 			// 

--- a/Fullscreenizer/AllApps.cs
+++ b/Fullscreenizer/AllApps.cs
@@ -61,6 +61,12 @@ namespace Fullscreenizer
 			_addedClasses = true;
 		}
 
+		private void lv_apps_DoubleClick(object sender, EventArgs e)
+		{
+			btn_addApp.PerformClick();
+			Close();
+		}
+
 		private void txt_filter_TextChanged(object sender, EventArgs e)
 		{
 			updateListView();

--- a/Fullscreenizer/AllApps.cs
+++ b/Fullscreenizer/AllApps.cs
@@ -51,11 +51,13 @@ namespace Fullscreenizer
 				return;
 			}
 
-			ListViewItem item = lv_apps.SelectedItems[0];
-			AppState state = _windowHandles[(IntPtr)item.Tag];
-			if( !_config.Classes.Contains(state.className) )
+			foreach (ListViewItem item in lv_apps.SelectedItems)
 			{
-				_config.Classes.Add(state.className);
+				AppState state = _windowHandles[(IntPtr)item.Tag];
+				if( !_config.Classes.Contains(state.className) )
+				{
+					_config.Classes.Add(state.className);
+				}
 			}
 
 			_addedClasses = true;

--- a/Fullscreenizer/AllApps.cs
+++ b/Fullscreenizer/AllApps.cs
@@ -32,13 +32,13 @@ namespace Fullscreenizer
 			_updateTimer.Start();
 		}
 
-		void _updateTimer_Tick(object sender, EventArgs e)
+		private void _updateTimer_Tick(object sender, EventArgs e)
 		{
 			refreshApps();
 			updateListView();
 		}
 
-		void AllApps_Load(object sender, System.EventArgs e)
+		private void AllApps_Load(object sender, System.EventArgs e)
 		{
 			refreshApps();
 			updateListView();
@@ -61,12 +61,12 @@ namespace Fullscreenizer
 			_addedClasses = true;
 		}
 
-		void txt_filter_TextChanged(object sender, EventArgs e)
+		private void txt_filter_TextChanged(object sender, EventArgs e)
 		{
 			updateListView();
 		}
 
-		void txt_filter_KeyDown(object sender, KeyEventArgs e)
+		private void txt_filter_KeyDown(object sender, KeyEventArgs e)
 		{
 			if( e.KeyCode == Keys.Escape )
 			{
@@ -74,7 +74,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void refreshApps()
+		private void refreshApps()
 		{
 			List<IntPtr> visibleWindows = Win32.getVisibleWindows(true);
 			foreach( IntPtr hwnd in visibleWindows )
@@ -110,7 +110,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void updateListView()
+		private void updateListView()
 		{
 			lv_apps.BeginUpdate();
 
@@ -157,7 +157,7 @@ namespace Fullscreenizer
 			lv_apps.EndUpdate();
 		}
 
-		void rebuildImageList()
+		private void rebuildImageList()
 		{
 			_windowImages.Images.Clear();
 			foreach( ListViewItem item in lv_apps.Items )

--- a/Fullscreenizer/AppState.cs
+++ b/Fullscreenizer/AppState.cs
@@ -25,11 +25,9 @@ namespace Fullscreenizer
 			// image can be null.
 
 			return !((string.IsNullOrWhiteSpace(className)) ||
-				      (originalStyle == IntPtr.Zero) ||
-							(initialX == 0) ||
-							(initialY == 0) ||
-							(initialWidth == 0) ||
-							(initialHeight == 0));
+						(originalStyle == IntPtr.Zero) ||
+						(initialWidth == 0) ||
+						(initialHeight == 0));
 		}
 	}
 }

--- a/Fullscreenizer/Config.cs
+++ b/Fullscreenizer/Config.cs
@@ -11,10 +11,11 @@ namespace Fullscreenizer
 	 *     | int    | default to 0     | Bit flag for the key of the hotkey.
 	 *     | bool   | default to true  | Scale the window when fullscreenizing.
 	 *     | bool   | default to true  | Move the window to the top-left when fullscreenizing.
+	 *     | bool   | default to true  | Lock the cursor to the application's window.
 	 *     | bool   | default to true  | Minimize the application to tray.
 	 *     | string | default to none  | All following lines are read as window classes to look for.
 	 */
-	public class Config
+    public class Config
 	{
 		private const string CONFIG_FILE = "fullscreenizer.cfg";
 
@@ -53,6 +54,13 @@ namespace Fullscreenizer
 			set{ _moveWindow = value; }
 		}
 
+		private bool _lockCursor;
+		public bool LockCursor
+		{
+			get{ return _lockCursor; }
+			set{ _lockCursor = value; }
+		}
+
 		private bool _minimizeToTray;
 		public bool MinimizeToTray
 		{
@@ -74,6 +82,7 @@ namespace Fullscreenizer
 			_keyFlag = Keys.Home;
 			_scaleWindow = true;
 			_moveWindow = true;
+			_lockCursor = true;
 			_minimizeToTray = true;
 			_classes.Clear();
 		}
@@ -155,7 +164,13 @@ namespace Fullscreenizer
 			{
 				return false;
 			}
-			
+
+			// Read lock cursor.
+			if( ((line = sr.ReadLine()) == null) || !bool.TryParse(line, out _lockCursor) )
+			{
+				return false;
+			}
+
 			// Read minimize to tray.
 			if( ((line = sr.ReadLine()) == null) || !bool.TryParse(line, out _minimizeToTray) )
 			{
@@ -190,6 +205,7 @@ namespace Fullscreenizer
 			sw.WriteLine(((int)_keyFlag).ToString());
 			sw.WriteLine(_scaleWindow.ToString());
 			sw.WriteLine(_moveWindow.ToString());
+			sw.WriteLine(_lockCursor.ToString());
 			sw.WriteLine(_minimizeToTray.ToString());
 			sw.Close();
 		}
@@ -202,6 +218,7 @@ namespace Fullscreenizer
 			sw.WriteLine(((int)_keyFlag).ToString());
 			sw.WriteLine(_scaleWindow.ToString());
 			sw.WriteLine(_moveWindow.ToString());
+			sw.WriteLine(_lockCursor.ToString());
 			sw.WriteLine(_minimizeToTray.ToString());
 			foreach( string curr in _classes )
 			{

--- a/Fullscreenizer/Config.cs
+++ b/Fullscreenizer/Config.cs
@@ -106,7 +106,7 @@ namespace Fullscreenizer
 			_fullscreenizeKeyFlags = Keys.Home;
 			_lockCursorHotkeyActive = false;
 			_lockCursorModifierFlags = Modifier.Ctrl;
-			_lockCursorKeyFlags = Keys.Home;
+			_lockCursorKeyFlags = Keys.End;
 			_scaleWindow = true;
 			_moveWindow = true;
 			_lockCursor = true;
@@ -208,11 +208,17 @@ namespace Fullscreenizer
 			_lockCursorKeyFlags = (Keys)tmpKey;
 
 			// If no modifier or no key is provided, fail.
-			if(_lockCursorModifierFlags == Modifier.None || _lockCursorKeyFlags == 0 )
+			if( _lockCursorModifierFlags == Modifier.None || _lockCursorKeyFlags == 0 )
 			{
 				return false;
 			}
-			
+
+			// If the lock cursor key is the same than the fullscreenize key, fail.
+			if( _lockCursorKeyFlags == _fullscreenizeKeyFlags)
+			{
+				return false;
+			}
+
 			return true;
 		}
 

--- a/Fullscreenizer/Config.cs
+++ b/Fullscreenizer/Config.cs
@@ -6,9 +6,12 @@ namespace Fullscreenizer
 {
     /**
 	 * Config format:
-	 *     | bool   | default to false | If the hotkey is activated upon load.
-	 *     | int    | default to 0     | Bit flag for the modifier of the hotkey modifier(s).
-	 *     | int    | default to 0     | Bit flag for the key of the hotkey.
+	 *     | bool   | default to false | If the fullscreenize hotkey is activated upon load.
+	 *     | int    | default to 0     | Bit flag for the modifier of the fullscreenize hotkey modifier(s).
+	 *     | int    | default to 0     | Bit flag for the key of the fullscreenize hotkey.
+	 *     | bool   | default to false | If the lock cursor hotkey is activated upon load.
+	 *     | int    | default to 0     | Bit flag for the modifier of the lock cursor hotkey modifier(s).
+	 *     | int    | default to 0     | Bit flag for the key of the lock cursor hotkey.
 	 *     | bool   | default to true  | Scale the window when fullscreenizing.
 	 *     | bool   | default to true  | Move the window to the top-left when fullscreenizing.
 	 *     | bool   | default to true  | Lock the cursor to the application's window.
@@ -19,25 +22,46 @@ namespace Fullscreenizer
 	{
 		private const string CONFIG_FILE = "fullscreenizer.cfg";
 
-		private bool _hotkeyActive;
-		public bool HotkeyActive
+		private bool _fullscreenizeHotkeyActive;
+		public bool FullscreenizeHotkeyActive
 		{
-			get{ return _hotkeyActive; }
-			set{ _hotkeyActive = value; }
+			get{ return _fullscreenizeHotkeyActive; }
+			set{ _fullscreenizeHotkeyActive = value; }
 		}
 
-		private Modifier _modifierFlags;
-		public Modifier ModifierFlags
+		private Modifier _fullscreenizeModifierFlags;
+		public Modifier FullscreenizeModifierFlags
 		{
-			get{ return _modifierFlags; }
-			set{ _modifierFlags = value; }
+			get{ return _fullscreenizeModifierFlags; }
+			set{ _fullscreenizeModifierFlags = value; }
 		}
 
-		private Keys _keyFlag;
-		public Keys KeyFlags
+		private Keys _fullscreenizeKeyFlags;
+		public Keys FullscreenizeKeyFlags
 		{
-			get{ return _keyFlag; }
-			set{ _keyFlag = value; }
+			get{ return _fullscreenizeKeyFlags; }
+			set{ _fullscreenizeKeyFlags = value; }
+		}
+
+		private bool _lockCursorHotkeyActive;
+		public bool LockCursorHotkeyActive
+		{
+			get{ return _lockCursorHotkeyActive; }
+			set{ _lockCursorHotkeyActive = value; }
+		}
+
+		private Modifier _lockCursorModifierFlags;
+		public Modifier LockCursorModifierFlags
+		{
+			get{ return _lockCursorModifierFlags; }
+			set{ _lockCursorModifierFlags = value; }
+		}
+
+		private Keys _lockCursorKeyFlags;
+		public Keys LockCursorKeyFlags
+		{
+			get{ return _lockCursorKeyFlags; }
+			set{ _lockCursorKeyFlags = value; }
 		}
 
 		private bool _scaleWindow;
@@ -77,9 +101,12 @@ namespace Fullscreenizer
 
 		public void reset()
 		{
-			_hotkeyActive = false;
-			_modifierFlags = Modifier.Ctrl;
-			_keyFlag = Keys.Home;
+			_fullscreenizeHotkeyActive = false;
+			_fullscreenizeModifierFlags = Modifier.Ctrl;
+			_fullscreenizeKeyFlags = Keys.Home;
+			_lockCursorHotkeyActive = false;
+			_lockCursorModifierFlags = Modifier.Ctrl;
+			_lockCursorKeyFlags = Keys.Home;
 			_scaleWindow = true;
 			_moveWindow = true;
 			_lockCursor = true;
@@ -99,7 +126,11 @@ namespace Fullscreenizer
 
 			// Read the hotkey and classes from the config file.
 			StreamReader sr = new StreamReader(new FileStream(CONFIG_FILE, FileMode.Open));
-			if( !readHotkeyPart(sr) )
+			if( !readFullscreenizeHotkeyPart(sr) )
+			{
+				return false;
+			}
+			if( !readLockCursorHotkeyPart(sr) )
 			{
 				return false;
 			}
@@ -113,35 +144,71 @@ namespace Fullscreenizer
 			return true;
 		}
 
-		private bool readHotkeyPart( StreamReader sr )
+		private bool readFullscreenizeHotkeyPart( StreamReader sr )
 		{
 			// One string used for all parameters.  If this is null after reading a line, there was no contents to read.
 			string line = null;
 
-			// Read the active status of the hotkey.
-			if( ((line = sr.ReadLine()) == null) || !bool.TryParse(line, out _hotkeyActive) )
+			// Read the active status of the fullscreenize hotkey.
+			if( ((line = sr.ReadLine()) == null) || !bool.TryParse(line, out _fullscreenizeHotkeyActive) )
 			{
 				return false;
 			}
 
-			// Read the hotkey modifier flags.
+			// Read the fullscreenize hotkey modifier flags.
 			int tmpModifier = 0;
 			if( ((line = sr.ReadLine()) == null) || !int.TryParse(line, out tmpModifier) )
 			{
 				return false;
 			}
-			_modifierFlags = (Modifier)tmpModifier;
+			_fullscreenizeModifierFlags = (Modifier)tmpModifier;
 
-			// Read the hotkey key flag.
+			// Read the fullscreenize hotkey key flag.
 			int tmpKey = 0;
 			if( ((line = sr.ReadLine()) == null) || !int.TryParse(line, out tmpKey) )
 			{
 				return false;
 			}
-			_keyFlag = (Keys)tmpKey;
+			_fullscreenizeKeyFlags = (Keys)tmpKey;
 
 			// If no modifier or no key is provided, fail.
-			if( _modifierFlags == Modifier.None || _keyFlag == 0 )
+			if( _fullscreenizeModifierFlags == Modifier.None || _fullscreenizeKeyFlags == 0 )
+			{
+				return false;
+			}
+			
+			return true;
+		}
+
+        private bool readLockCursorHotkeyPart( StreamReader sr )
+		{
+			// One string used for all parameters.  If this is null after reading a line, there was no contents to read.
+			string line = null;
+
+			// Read the active status of the lock cursor hotkey.
+			if( ((line = sr.ReadLine()) == null) || !bool.TryParse(line, out _lockCursorHotkeyActive) )
+			{
+				return false;
+			}
+
+			// Read the lock cursor hotkey modifier flags.
+			int tmpModifier = 0;
+			if( ((line = sr.ReadLine()) == null) || !int.TryParse(line, out tmpModifier) )
+			{
+				return false;
+			}
+			_lockCursorModifierFlags = (Modifier)tmpModifier;
+
+			// Read the lock cursor hotkey key flag.
+			int tmpKey = 0;
+			if( ((line = sr.ReadLine()) == null) || !int.TryParse(line, out tmpKey) )
+			{
+				return false;
+			}
+			_lockCursorKeyFlags = (Keys)tmpKey;
+
+			// If no modifier or no key is provided, fail.
+			if(_lockCursorModifierFlags == Modifier.None || _lockCursorKeyFlags == 0 )
 			{
 				return false;
 			}
@@ -200,9 +267,12 @@ namespace Fullscreenizer
 			reset(); // Just to be safe.
 
 			StreamWriter sw = new StreamWriter(new FileStream(CONFIG_FILE, FileMode.Create));
-			sw.WriteLine(_hotkeyActive.ToString());
-			sw.WriteLine(((int)_modifierFlags).ToString());
-			sw.WriteLine(((int)_keyFlag).ToString());
+			sw.WriteLine(_fullscreenizeHotkeyActive.ToString());
+			sw.WriteLine(((int)_fullscreenizeModifierFlags).ToString());
+			sw.WriteLine(((int)_fullscreenizeKeyFlags).ToString());
+			sw.WriteLine(_lockCursorHotkeyActive.ToString());
+			sw.WriteLine(((int)_lockCursorModifierFlags).ToString());
+			sw.WriteLine(((int)_lockCursorKeyFlags).ToString());
 			sw.WriteLine(_scaleWindow.ToString());
 			sw.WriteLine(_moveWindow.ToString());
 			sw.WriteLine(_lockCursor.ToString());
@@ -213,9 +283,12 @@ namespace Fullscreenizer
 		public void writeConfigFile()
 		{
 			StreamWriter sw = new StreamWriter(new FileStream(CONFIG_FILE, FileMode.Create));
-			sw.WriteLine(_hotkeyActive.ToString());
-			sw.WriteLine(((int)_modifierFlags).ToString());
-			sw.WriteLine(((int)_keyFlag).ToString());
+			sw.WriteLine(_fullscreenizeHotkeyActive.ToString());
+			sw.WriteLine(((int)_fullscreenizeModifierFlags).ToString());
+			sw.WriteLine(((int)_fullscreenizeKeyFlags).ToString());
+			sw.WriteLine(_lockCursorHotkeyActive.ToString());
+			sw.WriteLine(((int)_lockCursorModifierFlags).ToString());
+			sw.WriteLine(((int)_lockCursorKeyFlags).ToString());
 			sw.WriteLine(_scaleWindow.ToString());
 			sw.WriteLine(_moveWindow.ToString());
 			sw.WriteLine(_lockCursor.ToString());

--- a/Fullscreenizer/Fullscreenizer.Designer.cs
+++ b/Fullscreenizer/Fullscreenizer.Designer.cs
@@ -88,7 +88,6 @@
 			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
 			this.lv_apps.HideSelection = false;
 			this.lv_apps.Location = new System.Drawing.Point(6, 14);
-			this.lv_apps.MultiSelect = false;
 			this.lv_apps.Name = "lv_apps";
 			this.lv_apps.Size = new System.Drawing.Size(328, 148);
 			this.lv_apps.Sorting = System.Windows.Forms.SortOrder.Ascending;

--- a/Fullscreenizer/Fullscreenizer.Designer.cs
+++ b/Fullscreenizer/Fullscreenizer.Designer.cs
@@ -28,314 +28,329 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Fullscreenizer));
-			this.lbl_apps = new System.Windows.Forms.Label();
-			this.lv_apps = new System.Windows.Forms.ListView();
-			this.ch_title = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.btn_fullscreenizeApp = new System.Windows.Forms.Button();
-			this.gb_apps = new System.Windows.Forms.GroupBox();
-			this.chk_moveWindow = new System.Windows.Forms.CheckBox();
-			this.chk_scaleToFit = new System.Windows.Forms.CheckBox();
-			this.btn_removeApp = new System.Windows.Forms.Button();
-			this.btn_showAllApps = new System.Windows.Forms.Button();
-			this.chk_enableHotkey = new System.Windows.Forms.CheckBox();
-			this.gb_hotkey = new System.Windows.Forms.GroupBox();
-			this.cb_hotkeyKey = new System.Windows.Forms.ComboBox();
-			this.gb_hotkeyModifier = new System.Windows.Forms.GroupBox();
-			this.chk_hotkeyModAlt = new System.Windows.Forms.CheckBox();
-			this.chk_hotkeyModShift = new System.Windows.Forms.CheckBox();
-			this.chk_hotkeyModCtrl = new System.Windows.Forms.CheckBox();
-			this.lbl_website = new System.Windows.Forms.Label();
-			this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
-			this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.toolStripMenuItemShow = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItemClose = new System.Windows.Forms.ToolStripMenuItem();
-			this.chk_minimizeToTray = new System.Windows.Forms.CheckBox();
-			this.gb_apps.SuspendLayout();
-			this.gb_hotkey.SuspendLayout();
-			this.gb_hotkeyModifier.SuspendLayout();
-			this.contextMenuStrip.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// lbl_apps
-			// 
-			this.lbl_apps.AutoSize = true;
-			this.lbl_apps.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.lbl_apps.Location = new System.Drawing.Point(12, 9);
-			this.lbl_apps.Name = "lbl_apps";
-			this.lbl_apps.Size = new System.Drawing.Size(54, 24);
-			this.lbl_apps.TabIndex = 1;
-			this.lbl_apps.Text = "Apps";
-			// 
-			// lv_apps
-			// 
-			this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Fullscreenizer));
+            this.lbl_apps = new System.Windows.Forms.Label();
+            this.lv_apps = new System.Windows.Forms.ListView();
+            this.ch_title = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.btn_fullscreenizeApp = new System.Windows.Forms.Button();
+            this.gb_apps = new System.Windows.Forms.GroupBox();
+            this.chk_moveWindow = new System.Windows.Forms.CheckBox();
+            this.chk_scaleToFit = new System.Windows.Forms.CheckBox();
+            this.btn_removeApp = new System.Windows.Forms.Button();
+            this.btn_showAllApps = new System.Windows.Forms.Button();
+            this.chk_enableHotkey = new System.Windows.Forms.CheckBox();
+            this.gb_hotkey = new System.Windows.Forms.GroupBox();
+            this.cb_hotkeyKey = new System.Windows.Forms.ComboBox();
+            this.gb_hotkeyModifier = new System.Windows.Forms.GroupBox();
+            this.chk_hotkeyModAlt = new System.Windows.Forms.CheckBox();
+            this.chk_hotkeyModShift = new System.Windows.Forms.CheckBox();
+            this.chk_hotkeyModCtrl = new System.Windows.Forms.CheckBox();
+            this.lbl_website = new System.Windows.Forms.Label();
+            this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
+            this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolStripMenuItemShow = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItemClose = new System.Windows.Forms.ToolStripMenuItem();
+            this.chk_minimizeToTray = new System.Windows.Forms.CheckBox();
+            this.chk_lockCursor = new System.Windows.Forms.CheckBox();
+            this.gb_apps.SuspendLayout();
+            this.gb_hotkey.SuspendLayout();
+            this.gb_hotkeyModifier.SuspendLayout();
+            this.contextMenuStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // lbl_apps
+            // 
+            this.lbl_apps.AutoSize = true;
+            this.lbl_apps.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_apps.Location = new System.Drawing.Point(12, 9);
+            this.lbl_apps.Name = "lbl_apps";
+            this.lbl_apps.Size = new System.Drawing.Size(54, 24);
+            this.lbl_apps.TabIndex = 1;
+            this.lbl_apps.Text = "Apps";
+            // 
+            // lv_apps
+            // 
+            this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.ch_title});
-			this.lv_apps.FullRowSelect = true;
-			this.lv_apps.GridLines = true;
-			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-			this.lv_apps.HideSelection = false;
-			this.lv_apps.Location = new System.Drawing.Point(6, 14);
-			this.lv_apps.MultiSelect = false;
-			this.lv_apps.Name = "lv_apps";
-			this.lv_apps.Size = new System.Drawing.Size(328, 148);
-			this.lv_apps.Sorting = System.Windows.Forms.SortOrder.Ascending;
-			this.lv_apps.TabIndex = 0;
-			this.lv_apps.TabStop = false;
-			this.lv_apps.UseCompatibleStateImageBehavior = false;
-			this.lv_apps.View = System.Windows.Forms.View.Details;
-			// 
-			// ch_title
-			// 
-			this.ch_title.Text = "Title";
-			// 
-			// btn_fullscreenizeApp
-			// 
-			this.btn_fullscreenizeApp.Location = new System.Drawing.Point(6, 168);
-			this.btn_fullscreenizeApp.Name = "btn_fullscreenizeApp";
-			this.btn_fullscreenizeApp.Size = new System.Drawing.Size(76, 23);
-			this.btn_fullscreenizeApp.TabIndex = 3;
-			this.btn_fullscreenizeApp.TabStop = false;
-			this.btn_fullscreenizeApp.Text = "Fullscreenize";
-			this.btn_fullscreenizeApp.UseVisualStyleBackColor = true;
-			this.btn_fullscreenizeApp.Click += new System.EventHandler(this.btn_fullscreenizeApp_Click);
-			// 
-			// gb_apps
-			// 
-			this.gb_apps.Controls.Add(this.chk_moveWindow);
-			this.gb_apps.Controls.Add(this.chk_scaleToFit);
-			this.gb_apps.Controls.Add(this.btn_removeApp);
-			this.gb_apps.Controls.Add(this.lv_apps);
-			this.gb_apps.Controls.Add(this.btn_showAllApps);
-			this.gb_apps.Controls.Add(this.btn_fullscreenizeApp);
-			this.gb_apps.Location = new System.Drawing.Point(16, 36);
-			this.gb_apps.Name = "gb_apps";
-			this.gb_apps.Size = new System.Drawing.Size(342, 198);
-			this.gb_apps.TabIndex = 0;
-			this.gb_apps.TabStop = false;
-			// 
-			// chk_moveWindow
-			// 
-			this.chk_moveWindow.AutoSize = true;
-			this.chk_moveWindow.Checked = true;
-			this.chk_moveWindow.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chk_moveWindow.Location = new System.Drawing.Point(148, 172);
-			this.chk_moveWindow.Name = "chk_moveWindow";
-			this.chk_moveWindow.Size = new System.Drawing.Size(53, 17);
-			this.chk_moveWindow.TabIndex = 6;
-			this.chk_moveWindow.Text = "Move";
-			this.chk_moveWindow.UseVisualStyleBackColor = true;
-			this.chk_moveWindow.CheckedChanged += new System.EventHandler(this.chk_moveWindow_CheckedChanged);
-			// 
-			// chk_scaleToFit
-			// 
-			this.chk_scaleToFit.AutoSize = true;
-			this.chk_scaleToFit.Checked = true;
-			this.chk_scaleToFit.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chk_scaleToFit.Location = new System.Drawing.Point(88, 172);
-			this.chk_scaleToFit.Name = "chk_scaleToFit";
-			this.chk_scaleToFit.Size = new System.Drawing.Size(53, 17);
-			this.chk_scaleToFit.TabIndex = 5;
-			this.chk_scaleToFit.Text = "Scale";
-			this.chk_scaleToFit.UseVisualStyleBackColor = true;
-			this.chk_scaleToFit.CheckedChanged += new System.EventHandler(this.chk_scaleToFit_CheckedChanged);
-			// 
-			// btn_removeApp
-			// 
-			this.btn_removeApp.Location = new System.Drawing.Point(207, 168);
-			this.btn_removeApp.Name = "btn_removeApp";
-			this.btn_removeApp.Size = new System.Drawing.Size(57, 23);
-			this.btn_removeApp.TabIndex = 4;
-			this.btn_removeApp.Text = "Remove";
-			this.btn_removeApp.UseVisualStyleBackColor = true;
-			this.btn_removeApp.Click += new System.EventHandler(this.btn_removeApp_Click);
-			// 
-			// btn_showAllApps
-			// 
-			this.btn_showAllApps.Location = new System.Drawing.Point(270, 168);
-			this.btn_showAllApps.Name = "btn_showAllApps";
-			this.btn_showAllApps.Size = new System.Drawing.Size(64, 23);
-			this.btn_showAllApps.TabIndex = 3;
-			this.btn_showAllApps.TabStop = false;
-			this.btn_showAllApps.Text = "Show All";
-			this.btn_showAllApps.UseVisualStyleBackColor = true;
-			this.btn_showAllApps.Click += new System.EventHandler(this.btn_showAllApps_Click);
-			// 
-			// chk_enableHotkey
-			// 
-			this.chk_enableHotkey.AutoCheck = false;
-			this.chk_enableHotkey.AutoSize = true;
-			this.chk_enableHotkey.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.chk_enableHotkey.Location = new System.Drawing.Point(16, 236);
-			this.chk_enableHotkey.Name = "chk_enableHotkey";
-			this.chk_enableHotkey.Size = new System.Drawing.Size(87, 28);
-			this.chk_enableHotkey.TabIndex = 9;
-			this.chk_enableHotkey.TabStop = false;
-			this.chk_enableHotkey.Text = "Hotkey";
-			this.chk_enableHotkey.UseVisualStyleBackColor = true;
-			this.chk_enableHotkey.Click += new System.EventHandler(this.chk_enableHotkey_Click);
-			// 
-			// gb_hotkey
-			// 
-			this.gb_hotkey.Controls.Add(this.cb_hotkeyKey);
-			this.gb_hotkey.Controls.Add(this.gb_hotkeyModifier);
-			this.gb_hotkey.Location = new System.Drawing.Point(16, 261);
-			this.gb_hotkey.Name = "gb_hotkey";
-			this.gb_hotkey.Size = new System.Drawing.Size(342, 47);
-			this.gb_hotkey.TabIndex = 10;
-			this.gb_hotkey.TabStop = false;
-			// 
-			// cb_hotkeyKey
-			// 
-			this.cb_hotkeyKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cb_hotkeyKey.FormattingEnabled = true;
-			this.cb_hotkeyKey.Location = new System.Drawing.Point(151, 17);
-			this.cb_hotkeyKey.Name = "cb_hotkeyKey";
-			this.cb_hotkeyKey.Size = new System.Drawing.Size(183, 21);
-			this.cb_hotkeyKey.TabIndex = 11;
-			this.cb_hotkeyKey.TabStop = false;
-			this.cb_hotkeyKey.SelectionChangeCommitted += new System.EventHandler(this.cb_hotkeyKey_SelectionChangeCommitted);
-			// 
-			// gb_hotkeyModifier
-			// 
-			this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModAlt);
-			this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModShift);
-			this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModCtrl);
-			this.gb_hotkeyModifier.Location = new System.Drawing.Point(6, 9);
-			this.gb_hotkeyModifier.Name = "gb_hotkeyModifier";
-			this.gb_hotkeyModifier.Size = new System.Drawing.Size(139, 29);
-			this.gb_hotkeyModifier.TabIndex = 11;
-			this.gb_hotkeyModifier.TabStop = false;
-			// 
-			// chk_hotkeyModAlt
-			// 
-			this.chk_hotkeyModAlt.AutoCheck = false;
-			this.chk_hotkeyModAlt.AutoSize = true;
-			this.chk_hotkeyModAlt.Location = new System.Drawing.Point(100, 10);
-			this.chk_hotkeyModAlt.Name = "chk_hotkeyModAlt";
-			this.chk_hotkeyModAlt.Size = new System.Drawing.Size(37, 17);
-			this.chk_hotkeyModAlt.TabIndex = 0;
-			this.chk_hotkeyModAlt.TabStop = false;
-			this.chk_hotkeyModAlt.Text = "alt";
-			this.chk_hotkeyModAlt.UseVisualStyleBackColor = true;
-			this.chk_hotkeyModAlt.Click += new System.EventHandler(this.chk_hotkeyModAlt_Click);
-			// 
-			// chk_hotkeyModShift
-			// 
-			this.chk_hotkeyModShift.AutoCheck = false;
-			this.chk_hotkeyModShift.AutoSize = true;
-			this.chk_hotkeyModShift.Location = new System.Drawing.Point(49, 10);
-			this.chk_hotkeyModShift.Name = "chk_hotkeyModShift";
-			this.chk_hotkeyModShift.Size = new System.Drawing.Size(45, 17);
-			this.chk_hotkeyModShift.TabIndex = 0;
-			this.chk_hotkeyModShift.TabStop = false;
-			this.chk_hotkeyModShift.Text = "shift";
-			this.chk_hotkeyModShift.UseVisualStyleBackColor = true;
-			this.chk_hotkeyModShift.Click += new System.EventHandler(this.chk_hotkeyModShift_Click);
-			// 
-			// chk_hotkeyModCtrl
-			// 
-			this.chk_hotkeyModCtrl.AutoCheck = false;
-			this.chk_hotkeyModCtrl.AutoSize = true;
-			this.chk_hotkeyModCtrl.Checked = true;
-			this.chk_hotkeyModCtrl.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chk_hotkeyModCtrl.Location = new System.Drawing.Point(5, 10);
-			this.chk_hotkeyModCtrl.Name = "chk_hotkeyModCtrl";
-			this.chk_hotkeyModCtrl.Size = new System.Drawing.Size(40, 17);
-			this.chk_hotkeyModCtrl.TabIndex = 0;
-			this.chk_hotkeyModCtrl.TabStop = false;
-			this.chk_hotkeyModCtrl.Text = "ctrl";
-			this.chk_hotkeyModCtrl.UseVisualStyleBackColor = true;
-			this.chk_hotkeyModCtrl.Click += new System.EventHandler(this.chk_hotkeyModCtrl_Click);
-			// 
-			// lbl_website
-			// 
-			this.lbl_website.AutoSize = true;
-			this.lbl_website.Cursor = System.Windows.Forms.Cursors.Hand;
-			this.lbl_website.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.lbl_website.Location = new System.Drawing.Point(273, 3);
-			this.lbl_website.Name = "lbl_website";
-			this.lbl_website.Size = new System.Drawing.Size(93, 13);
-			this.lbl_website.TabIndex = 12;
-			this.lbl_website.Text = "GitHub Repository";
-			this.lbl_website.Click += new System.EventHandler(this.lbl_website_Click);
-			// 
-			// notifyIcon
-			// 
-			this.notifyIcon.ContextMenuStrip = this.contextMenuStrip;
-			this.notifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon.Icon")));
-			this.notifyIcon.Text = "Fullscreenizer";
-			this.notifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon_MouseClick);
-			// 
-			// contextMenuStrip
-			// 
-			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lv_apps.FullRowSelect = true;
+            this.lv_apps.GridLines = true;
+            this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lv_apps.HideSelection = false;
+            this.lv_apps.Location = new System.Drawing.Point(6, 14);
+            this.lv_apps.MultiSelect = false;
+            this.lv_apps.Name = "lv_apps";
+            this.lv_apps.Size = new System.Drawing.Size(328, 148);
+            this.lv_apps.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.lv_apps.TabIndex = 0;
+            this.lv_apps.TabStop = false;
+            this.lv_apps.UseCompatibleStateImageBehavior = false;
+            this.lv_apps.View = System.Windows.Forms.View.Details;
+            // 
+            // ch_title
+            // 
+            this.ch_title.Text = "Title";
+            // 
+            // btn_fullscreenizeApp
+            // 
+            this.btn_fullscreenizeApp.Location = new System.Drawing.Point(6, 168);
+            this.btn_fullscreenizeApp.Name = "btn_fullscreenizeApp";
+            this.btn_fullscreenizeApp.Size = new System.Drawing.Size(76, 23);
+            this.btn_fullscreenizeApp.TabIndex = 3;
+            this.btn_fullscreenizeApp.TabStop = false;
+            this.btn_fullscreenizeApp.Text = "Fullscreenize";
+            this.btn_fullscreenizeApp.UseVisualStyleBackColor = true;
+            this.btn_fullscreenizeApp.Click += new System.EventHandler(this.btn_fullscreenizeApp_Click);
+            // 
+            // gb_apps
+            // 
+            this.gb_apps.Controls.Add(this.chk_moveWindow);
+            this.gb_apps.Controls.Add(this.chk_scaleToFit);
+            this.gb_apps.Controls.Add(this.btn_removeApp);
+            this.gb_apps.Controls.Add(this.lv_apps);
+            this.gb_apps.Controls.Add(this.btn_showAllApps);
+            this.gb_apps.Controls.Add(this.btn_fullscreenizeApp);
+            this.gb_apps.Location = new System.Drawing.Point(16, 36);
+            this.gb_apps.Name = "gb_apps";
+            this.gb_apps.Size = new System.Drawing.Size(342, 198);
+            this.gb_apps.TabIndex = 0;
+            this.gb_apps.TabStop = false;
+            // 
+            // chk_moveWindow
+            // 
+            this.chk_moveWindow.AutoSize = true;
+            this.chk_moveWindow.Checked = true;
+            this.chk_moveWindow.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chk_moveWindow.Location = new System.Drawing.Point(148, 172);
+            this.chk_moveWindow.Name = "chk_moveWindow";
+            this.chk_moveWindow.Size = new System.Drawing.Size(53, 17);
+            this.chk_moveWindow.TabIndex = 6;
+            this.chk_moveWindow.Text = "Move";
+            this.chk_moveWindow.UseVisualStyleBackColor = true;
+            this.chk_moveWindow.CheckedChanged += new System.EventHandler(this.chk_moveWindow_CheckedChanged);
+            // 
+            // chk_scaleToFit
+            // 
+            this.chk_scaleToFit.AutoSize = true;
+            this.chk_scaleToFit.Checked = true;
+            this.chk_scaleToFit.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chk_scaleToFit.Location = new System.Drawing.Point(88, 172);
+            this.chk_scaleToFit.Name = "chk_scaleToFit";
+            this.chk_scaleToFit.Size = new System.Drawing.Size(53, 17);
+            this.chk_scaleToFit.TabIndex = 5;
+            this.chk_scaleToFit.Text = "Scale";
+            this.chk_scaleToFit.UseVisualStyleBackColor = true;
+            this.chk_scaleToFit.CheckedChanged += new System.EventHandler(this.chk_scaleToFit_CheckedChanged);
+            // 
+            // btn_removeApp
+            // 
+            this.btn_removeApp.Location = new System.Drawing.Point(207, 168);
+            this.btn_removeApp.Name = "btn_removeApp";
+            this.btn_removeApp.Size = new System.Drawing.Size(57, 23);
+            this.btn_removeApp.TabIndex = 4;
+            this.btn_removeApp.Text = "Remove";
+            this.btn_removeApp.UseVisualStyleBackColor = true;
+            this.btn_removeApp.Click += new System.EventHandler(this.btn_removeApp_Click);
+            // 
+            // btn_showAllApps
+            // 
+            this.btn_showAllApps.Location = new System.Drawing.Point(270, 168);
+            this.btn_showAllApps.Name = "btn_showAllApps";
+            this.btn_showAllApps.Size = new System.Drawing.Size(64, 23);
+            this.btn_showAllApps.TabIndex = 3;
+            this.btn_showAllApps.TabStop = false;
+            this.btn_showAllApps.Text = "Show All";
+            this.btn_showAllApps.UseVisualStyleBackColor = true;
+            this.btn_showAllApps.Click += new System.EventHandler(this.btn_showAllApps_Click);
+            // 
+            // chk_enableHotkey
+            // 
+            this.chk_enableHotkey.AutoCheck = false;
+            this.chk_enableHotkey.AutoSize = true;
+            this.chk_enableHotkey.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chk_enableHotkey.Location = new System.Drawing.Point(16, 236);
+            this.chk_enableHotkey.Name = "chk_enableHotkey";
+            this.chk_enableHotkey.Size = new System.Drawing.Size(87, 28);
+            this.chk_enableHotkey.TabIndex = 9;
+            this.chk_enableHotkey.TabStop = false;
+            this.chk_enableHotkey.Text = "Hotkey";
+            this.chk_enableHotkey.UseVisualStyleBackColor = true;
+            this.chk_enableHotkey.Click += new System.EventHandler(this.chk_enableHotkey_Click);
+            // 
+            // gb_hotkey
+            // 
+            this.gb_hotkey.Controls.Add(this.cb_hotkeyKey);
+            this.gb_hotkey.Controls.Add(this.gb_hotkeyModifier);
+            this.gb_hotkey.Location = new System.Drawing.Point(16, 261);
+            this.gb_hotkey.Name = "gb_hotkey";
+            this.gb_hotkey.Size = new System.Drawing.Size(342, 47);
+            this.gb_hotkey.TabIndex = 10;
+            this.gb_hotkey.TabStop = false;
+            // 
+            // cb_hotkeyKey
+            // 
+            this.cb_hotkeyKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cb_hotkeyKey.FormattingEnabled = true;
+            this.cb_hotkeyKey.Location = new System.Drawing.Point(151, 17);
+            this.cb_hotkeyKey.Name = "cb_hotkeyKey";
+            this.cb_hotkeyKey.Size = new System.Drawing.Size(183, 21);
+            this.cb_hotkeyKey.TabIndex = 11;
+            this.cb_hotkeyKey.TabStop = false;
+            this.cb_hotkeyKey.SelectionChangeCommitted += new System.EventHandler(this.cb_hotkeyKey_SelectionChangeCommitted);
+            // 
+            // gb_hotkeyModifier
+            // 
+            this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModAlt);
+            this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModShift);
+            this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModCtrl);
+            this.gb_hotkeyModifier.Location = new System.Drawing.Point(6, 9);
+            this.gb_hotkeyModifier.Name = "gb_hotkeyModifier";
+            this.gb_hotkeyModifier.Size = new System.Drawing.Size(139, 29);
+            this.gb_hotkeyModifier.TabIndex = 11;
+            this.gb_hotkeyModifier.TabStop = false;
+            // 
+            // chk_hotkeyModAlt
+            // 
+            this.chk_hotkeyModAlt.AutoCheck = false;
+            this.chk_hotkeyModAlt.AutoSize = true;
+            this.chk_hotkeyModAlt.Location = new System.Drawing.Point(100, 10);
+            this.chk_hotkeyModAlt.Name = "chk_hotkeyModAlt";
+            this.chk_hotkeyModAlt.Size = new System.Drawing.Size(37, 17);
+            this.chk_hotkeyModAlt.TabIndex = 0;
+            this.chk_hotkeyModAlt.TabStop = false;
+            this.chk_hotkeyModAlt.Text = "alt";
+            this.chk_hotkeyModAlt.UseVisualStyleBackColor = true;
+            this.chk_hotkeyModAlt.Click += new System.EventHandler(this.chk_hotkeyModAlt_Click);
+            // 
+            // chk_hotkeyModShift
+            // 
+            this.chk_hotkeyModShift.AutoCheck = false;
+            this.chk_hotkeyModShift.AutoSize = true;
+            this.chk_hotkeyModShift.Location = new System.Drawing.Point(49, 10);
+            this.chk_hotkeyModShift.Name = "chk_hotkeyModShift";
+            this.chk_hotkeyModShift.Size = new System.Drawing.Size(45, 17);
+            this.chk_hotkeyModShift.TabIndex = 0;
+            this.chk_hotkeyModShift.TabStop = false;
+            this.chk_hotkeyModShift.Text = "shift";
+            this.chk_hotkeyModShift.UseVisualStyleBackColor = true;
+            this.chk_hotkeyModShift.Click += new System.EventHandler(this.chk_hotkeyModShift_Click);
+            // 
+            // chk_hotkeyModCtrl
+            // 
+            this.chk_hotkeyModCtrl.AutoCheck = false;
+            this.chk_hotkeyModCtrl.AutoSize = true;
+            this.chk_hotkeyModCtrl.Checked = true;
+            this.chk_hotkeyModCtrl.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chk_hotkeyModCtrl.Location = new System.Drawing.Point(5, 10);
+            this.chk_hotkeyModCtrl.Name = "chk_hotkeyModCtrl";
+            this.chk_hotkeyModCtrl.Size = new System.Drawing.Size(40, 17);
+            this.chk_hotkeyModCtrl.TabIndex = 0;
+            this.chk_hotkeyModCtrl.TabStop = false;
+            this.chk_hotkeyModCtrl.Text = "ctrl";
+            this.chk_hotkeyModCtrl.UseVisualStyleBackColor = true;
+            this.chk_hotkeyModCtrl.Click += new System.EventHandler(this.chk_hotkeyModCtrl_Click);
+            // 
+            // lbl_website
+            // 
+            this.lbl_website.AutoSize = true;
+            this.lbl_website.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.lbl_website.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_website.Location = new System.Drawing.Point(273, 3);
+            this.lbl_website.Name = "lbl_website";
+            this.lbl_website.Size = new System.Drawing.Size(93, 13);
+            this.lbl_website.TabIndex = 12;
+            this.lbl_website.Text = "GitHub Repository";
+            this.lbl_website.Click += new System.EventHandler(this.lbl_website_Click);
+            // 
+            // notifyIcon
+            // 
+            this.notifyIcon.ContextMenuStrip = this.contextMenuStrip;
+            this.notifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon.Icon")));
+            this.notifyIcon.Text = "Fullscreenizer";
+            this.notifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon_MouseClick);
+            // 
+            // contextMenuStrip
+            // 
+            this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItemShow,
             this.toolStripSeparator,
             this.toolStripMenuItemClose});
-			this.contextMenuStrip.Name = "contextMenuStrip";
-			this.contextMenuStrip.Size = new System.Drawing.Size(104, 54);
-			// 
-			// toolStripMenuItemShow
-			// 
-			this.toolStripMenuItemShow.Name = "toolStripMenuItemShow";
-			this.toolStripMenuItemShow.Size = new System.Drawing.Size(103, 22);
-			this.toolStripMenuItemShow.Text = "Show";
-			this.toolStripMenuItemShow.Click += new System.EventHandler(this.toolStripMenuItemShow_Click);
-			// 
-			// toolStripSeparator
-			// 
-			this.toolStripSeparator.Name = "toolStripSeparator";
-			this.toolStripSeparator.Size = new System.Drawing.Size(100, 6);
-			// 
-			// toolStripMenuItemClose
-			// 
-			this.toolStripMenuItemClose.Name = "toolStripMenuItemClose";
-			this.toolStripMenuItemClose.Size = new System.Drawing.Size(103, 22);
-			this.toolStripMenuItemClose.Text = "Close";
-			this.toolStripMenuItemClose.Click += new System.EventHandler(this.toolStripMenuItemClose_Click);
-			// 
-			// chk_minimizeToTray
-			// 
-			this.chk_minimizeToTray.AutoSize = true;
-			this.chk_minimizeToTray.Checked = true;
-			this.chk_minimizeToTray.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chk_minimizeToTray.Location = new System.Drawing.Point(262, 23);
-			this.chk_minimizeToTray.Name = "chk_minimizeToTray";
-			this.chk_minimizeToTray.Size = new System.Drawing.Size(98, 17);
-			this.chk_minimizeToTray.TabIndex = 7;
-			this.chk_minimizeToTray.Text = "Minimize to tray";
-			this.chk_minimizeToTray.UseVisualStyleBackColor = true;
-			this.chk_minimizeToTray.CheckedChanged += new System.EventHandler(this.chk_minimizeToTray_CheckedChanged);
-			// 
-			// Fullscreenizer
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(369, 315);
-			this.Controls.Add(this.chk_minimizeToTray);
-			this.Controls.Add(this.lbl_website);
-			this.Controls.Add(this.gb_hotkey);
-			this.Controls.Add(this.chk_enableHotkey);
-			this.Controls.Add(this.gb_apps);
-			this.Controls.Add(this.lbl_apps);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MaximizeBox = false;
-			this.Name = "Fullscreenizer";
-			this.Text = "Fullscreenizer";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Fullscreenizer_FormClosing);
-			this.Resize += new System.EventHandler(this.Fullscreenizer_Resize);
-			this.gb_apps.ResumeLayout(false);
-			this.gb_apps.PerformLayout();
-			this.gb_hotkey.ResumeLayout(false);
-			this.gb_hotkeyModifier.ResumeLayout(false);
-			this.gb_hotkeyModifier.PerformLayout();
-			this.contextMenuStrip.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.contextMenuStrip.Name = "contextMenuStrip";
+            this.contextMenuStrip.Size = new System.Drawing.Size(104, 54);
+            // 
+            // toolStripMenuItemShow
+            // 
+            this.toolStripMenuItemShow.Name = "toolStripMenuItemShow";
+            this.toolStripMenuItemShow.Size = new System.Drawing.Size(103, 22);
+            this.toolStripMenuItemShow.Text = "Show";
+            this.toolStripMenuItemShow.Click += new System.EventHandler(this.toolStripMenuItemShow_Click);
+            // 
+            // toolStripSeparator
+            // 
+            this.toolStripSeparator.Name = "toolStripSeparator";
+            this.toolStripSeparator.Size = new System.Drawing.Size(100, 6);
+            // 
+            // toolStripMenuItemClose
+            // 
+            this.toolStripMenuItemClose.Name = "toolStripMenuItemClose";
+            this.toolStripMenuItemClose.Size = new System.Drawing.Size(103, 22);
+            this.toolStripMenuItemClose.Text = "Close";
+            this.toolStripMenuItemClose.Click += new System.EventHandler(this.toolStripMenuItemClose_Click);
+            // 
+            // chk_minimizeToTray
+            // 
+            this.chk_minimizeToTray.AutoSize = true;
+            this.chk_minimizeToTray.Checked = true;
+            this.chk_minimizeToTray.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chk_minimizeToTray.Location = new System.Drawing.Point(262, 23);
+            this.chk_minimizeToTray.Name = "chk_minimizeToTray";
+            this.chk_minimizeToTray.Size = new System.Drawing.Size(98, 17);
+            this.chk_minimizeToTray.TabIndex = 7;
+            this.chk_minimizeToTray.Text = "Minimize to tray";
+            this.chk_minimizeToTray.UseVisualStyleBackColor = true;
+            this.chk_minimizeToTray.CheckedChanged += new System.EventHandler(this.chk_minimizeToTray_CheckedChanged);
+            // 
+            // chk_LockCursor
+            // 
+            this.chk_lockCursor.AutoSize = true;
+            this.chk_lockCursor.Checked = true;
+            this.chk_lockCursor.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chk_lockCursor.Location = new System.Drawing.Point(167, 23);
+            this.chk_lockCursor.Name = "chk_lockCursor";
+            this.chk_lockCursor.Size = new System.Drawing.Size(82, 17);
+            this.chk_lockCursor.TabIndex = 13;
+            this.chk_lockCursor.Text = "Lock cursor";
+            this.chk_lockCursor.UseVisualStyleBackColor = true;
+            this.chk_lockCursor.CheckedChanged += new System.EventHandler(this.chk_lockCursor_CheckedChanged);
+            // 
+            // Fullscreenizer
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(369, 315);
+            this.Controls.Add(this.chk_lockCursor);
+            this.Controls.Add(this.chk_minimizeToTray);
+            this.Controls.Add(this.lbl_website);
+            this.Controls.Add(this.gb_hotkey);
+            this.Controls.Add(this.chk_enableHotkey);
+            this.Controls.Add(this.gb_apps);
+            this.Controls.Add(this.lbl_apps);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.Name = "Fullscreenizer";
+            this.Text = "Fullscreenizer";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Fullscreenizer_FormClosing);
+            this.Resize += new System.EventHandler(this.Fullscreenizer_Resize);
+            this.gb_apps.ResumeLayout(false);
+            this.gb_apps.PerformLayout();
+            this.gb_hotkey.ResumeLayout(false);
+            this.gb_hotkeyModifier.ResumeLayout(false);
+            this.gb_hotkeyModifier.PerformLayout();
+            this.contextMenuStrip.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -364,6 +379,7 @@
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator;
 		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemClose;
 		private System.Windows.Forms.CheckBox chk_minimizeToTray;
-	}
+        private System.Windows.Forms.CheckBox chk_lockCursor;
+    }
 }
 

--- a/Fullscreenizer/Fullscreenizer.Designer.cs
+++ b/Fullscreenizer/Fullscreenizer.Designer.cs
@@ -28,329 +28,430 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Fullscreenizer));
-            this.lbl_apps = new System.Windows.Forms.Label();
-            this.lv_apps = new System.Windows.Forms.ListView();
-            this.ch_title = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.btn_fullscreenizeApp = new System.Windows.Forms.Button();
-            this.gb_apps = new System.Windows.Forms.GroupBox();
-            this.chk_moveWindow = new System.Windows.Forms.CheckBox();
-            this.chk_scaleToFit = new System.Windows.Forms.CheckBox();
-            this.btn_removeApp = new System.Windows.Forms.Button();
-            this.btn_showAllApps = new System.Windows.Forms.Button();
-            this.chk_enableHotkey = new System.Windows.Forms.CheckBox();
-            this.gb_hotkey = new System.Windows.Forms.GroupBox();
-            this.cb_hotkeyKey = new System.Windows.Forms.ComboBox();
-            this.gb_hotkeyModifier = new System.Windows.Forms.GroupBox();
-            this.chk_hotkeyModAlt = new System.Windows.Forms.CheckBox();
-            this.chk_hotkeyModShift = new System.Windows.Forms.CheckBox();
-            this.chk_hotkeyModCtrl = new System.Windows.Forms.CheckBox();
-            this.lbl_website = new System.Windows.Forms.Label();
-            this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
-            this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.toolStripMenuItemShow = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItemClose = new System.Windows.Forms.ToolStripMenuItem();
-            this.chk_minimizeToTray = new System.Windows.Forms.CheckBox();
-            this.chk_lockCursor = new System.Windows.Forms.CheckBox();
-            this.gb_apps.SuspendLayout();
-            this.gb_hotkey.SuspendLayout();
-            this.gb_hotkeyModifier.SuspendLayout();
-            this.contextMenuStrip.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // lbl_apps
-            // 
-            this.lbl_apps.AutoSize = true;
-            this.lbl_apps.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbl_apps.Location = new System.Drawing.Point(12, 9);
-            this.lbl_apps.Name = "lbl_apps";
-            this.lbl_apps.Size = new System.Drawing.Size(54, 24);
-            this.lbl_apps.TabIndex = 1;
-            this.lbl_apps.Text = "Apps";
-            // 
-            // lv_apps
-            // 
-            this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+			this.components = new System.ComponentModel.Container();
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Fullscreenizer));
+			this.lbl_apps = new System.Windows.Forms.Label();
+			this.lv_apps = new System.Windows.Forms.ListView();
+			this.ch_title = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.btn_fullscreenizeApp = new System.Windows.Forms.Button();
+			this.gb_apps = new System.Windows.Forms.GroupBox();
+			this.chk_moveWindow = new System.Windows.Forms.CheckBox();
+			this.chk_scaleToFit = new System.Windows.Forms.CheckBox();
+			this.btn_removeApp = new System.Windows.Forms.Button();
+			this.btn_showAllApps = new System.Windows.Forms.Button();
+			this.lbl_website = new System.Windows.Forms.Label();
+			this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
+			this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.toolStripMenuItemShow = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItemClose = new System.Windows.Forms.ToolStripMenuItem();
+			this.chk_minimizeToTray = new System.Windows.Forms.CheckBox();
+			this.chk_lockCursor = new System.Windows.Forms.CheckBox();
+			this.chk_fullscreenizeEnableHotkey = new System.Windows.Forms.CheckBox();
+			this.gb_hotkeyModifier = new System.Windows.Forms.GroupBox();
+			this.chk_fullscreenizeHotkeyModAlt = new System.Windows.Forms.CheckBox();
+			this.chk_fullscreenizeHotkeyModShift = new System.Windows.Forms.CheckBox();
+			this.chk_fullscreenizeHotkeyModCtrl = new System.Windows.Forms.CheckBox();
+			this.cb_fullscreenizeHotkeyKey = new System.Windows.Forms.ComboBox();
+			this.gb_fullscreenizeHotkey = new System.Windows.Forms.GroupBox();
+			this.gb_lockCursorHotkey = new System.Windows.Forms.GroupBox();
+			this.cb_lockCursorHotkeyKey = new System.Windows.Forms.ComboBox();
+			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.chk_lockCursorHotkeyModAlt = new System.Windows.Forms.CheckBox();
+			this.chk_lockCursorHotkeyModShift = new System.Windows.Forms.CheckBox();
+			this.chk_lockCursorHotkeyModCtrl = new System.Windows.Forms.CheckBox();
+			this.chk_lockCursorEnableHotkey = new System.Windows.Forms.CheckBox();
+			this.gb_apps.SuspendLayout();
+			this.contextMenuStrip.SuspendLayout();
+			this.gb_hotkeyModifier.SuspendLayout();
+			this.gb_fullscreenizeHotkey.SuspendLayout();
+			this.gb_lockCursorHotkey.SuspendLayout();
+			this.groupBox2.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// lbl_apps
+			// 
+			this.lbl_apps.AutoSize = true;
+			this.lbl_apps.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.lbl_apps.Location = new System.Drawing.Point(12, 9);
+			this.lbl_apps.Name = "lbl_apps";
+			this.lbl_apps.Size = new System.Drawing.Size(54, 24);
+			this.lbl_apps.TabIndex = 1;
+			this.lbl_apps.Text = "Apps";
+			// 
+			// lv_apps
+			// 
+			this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.ch_title});
-            this.lv_apps.FullRowSelect = true;
-            this.lv_apps.GridLines = true;
-            this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.lv_apps.HideSelection = false;
-            this.lv_apps.Location = new System.Drawing.Point(6, 14);
-            this.lv_apps.MultiSelect = false;
-            this.lv_apps.Name = "lv_apps";
-            this.lv_apps.Size = new System.Drawing.Size(328, 148);
-            this.lv_apps.Sorting = System.Windows.Forms.SortOrder.Ascending;
-            this.lv_apps.TabIndex = 0;
-            this.lv_apps.TabStop = false;
-            this.lv_apps.UseCompatibleStateImageBehavior = false;
-            this.lv_apps.View = System.Windows.Forms.View.Details;
-            // 
-            // ch_title
-            // 
-            this.ch_title.Text = "Title";
-            // 
-            // btn_fullscreenizeApp
-            // 
-            this.btn_fullscreenizeApp.Location = new System.Drawing.Point(6, 168);
-            this.btn_fullscreenizeApp.Name = "btn_fullscreenizeApp";
-            this.btn_fullscreenizeApp.Size = new System.Drawing.Size(76, 23);
-            this.btn_fullscreenizeApp.TabIndex = 3;
-            this.btn_fullscreenizeApp.TabStop = false;
-            this.btn_fullscreenizeApp.Text = "Fullscreenize";
-            this.btn_fullscreenizeApp.UseVisualStyleBackColor = true;
-            this.btn_fullscreenizeApp.Click += new System.EventHandler(this.btn_fullscreenizeApp_Click);
-            // 
-            // gb_apps
-            // 
-            this.gb_apps.Controls.Add(this.chk_moveWindow);
-            this.gb_apps.Controls.Add(this.chk_scaleToFit);
-            this.gb_apps.Controls.Add(this.btn_removeApp);
-            this.gb_apps.Controls.Add(this.lv_apps);
-            this.gb_apps.Controls.Add(this.btn_showAllApps);
-            this.gb_apps.Controls.Add(this.btn_fullscreenizeApp);
-            this.gb_apps.Location = new System.Drawing.Point(16, 36);
-            this.gb_apps.Name = "gb_apps";
-            this.gb_apps.Size = new System.Drawing.Size(342, 198);
-            this.gb_apps.TabIndex = 0;
-            this.gb_apps.TabStop = false;
-            // 
-            // chk_moveWindow
-            // 
-            this.chk_moveWindow.AutoSize = true;
-            this.chk_moveWindow.Checked = true;
-            this.chk_moveWindow.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chk_moveWindow.Location = new System.Drawing.Point(148, 172);
-            this.chk_moveWindow.Name = "chk_moveWindow";
-            this.chk_moveWindow.Size = new System.Drawing.Size(53, 17);
-            this.chk_moveWindow.TabIndex = 6;
-            this.chk_moveWindow.Text = "Move";
-            this.chk_moveWindow.UseVisualStyleBackColor = true;
-            this.chk_moveWindow.CheckedChanged += new System.EventHandler(this.chk_moveWindow_CheckedChanged);
-            // 
-            // chk_scaleToFit
-            // 
-            this.chk_scaleToFit.AutoSize = true;
-            this.chk_scaleToFit.Checked = true;
-            this.chk_scaleToFit.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chk_scaleToFit.Location = new System.Drawing.Point(88, 172);
-            this.chk_scaleToFit.Name = "chk_scaleToFit";
-            this.chk_scaleToFit.Size = new System.Drawing.Size(53, 17);
-            this.chk_scaleToFit.TabIndex = 5;
-            this.chk_scaleToFit.Text = "Scale";
-            this.chk_scaleToFit.UseVisualStyleBackColor = true;
-            this.chk_scaleToFit.CheckedChanged += new System.EventHandler(this.chk_scaleToFit_CheckedChanged);
-            // 
-            // btn_removeApp
-            // 
-            this.btn_removeApp.Location = new System.Drawing.Point(207, 168);
-            this.btn_removeApp.Name = "btn_removeApp";
-            this.btn_removeApp.Size = new System.Drawing.Size(57, 23);
-            this.btn_removeApp.TabIndex = 4;
-            this.btn_removeApp.Text = "Remove";
-            this.btn_removeApp.UseVisualStyleBackColor = true;
-            this.btn_removeApp.Click += new System.EventHandler(this.btn_removeApp_Click);
-            // 
-            // btn_showAllApps
-            // 
-            this.btn_showAllApps.Location = new System.Drawing.Point(270, 168);
-            this.btn_showAllApps.Name = "btn_showAllApps";
-            this.btn_showAllApps.Size = new System.Drawing.Size(64, 23);
-            this.btn_showAllApps.TabIndex = 3;
-            this.btn_showAllApps.TabStop = false;
-            this.btn_showAllApps.Text = "Show All";
-            this.btn_showAllApps.UseVisualStyleBackColor = true;
-            this.btn_showAllApps.Click += new System.EventHandler(this.btn_showAllApps_Click);
-            // 
-            // chk_enableHotkey
-            // 
-            this.chk_enableHotkey.AutoCheck = false;
-            this.chk_enableHotkey.AutoSize = true;
-            this.chk_enableHotkey.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.chk_enableHotkey.Location = new System.Drawing.Point(16, 236);
-            this.chk_enableHotkey.Name = "chk_enableHotkey";
-            this.chk_enableHotkey.Size = new System.Drawing.Size(87, 28);
-            this.chk_enableHotkey.TabIndex = 9;
-            this.chk_enableHotkey.TabStop = false;
-            this.chk_enableHotkey.Text = "Hotkey";
-            this.chk_enableHotkey.UseVisualStyleBackColor = true;
-            this.chk_enableHotkey.Click += new System.EventHandler(this.chk_enableHotkey_Click);
-            // 
-            // gb_hotkey
-            // 
-            this.gb_hotkey.Controls.Add(this.cb_hotkeyKey);
-            this.gb_hotkey.Controls.Add(this.gb_hotkeyModifier);
-            this.gb_hotkey.Location = new System.Drawing.Point(16, 261);
-            this.gb_hotkey.Name = "gb_hotkey";
-            this.gb_hotkey.Size = new System.Drawing.Size(342, 47);
-            this.gb_hotkey.TabIndex = 10;
-            this.gb_hotkey.TabStop = false;
-            // 
-            // cb_hotkeyKey
-            // 
-            this.cb_hotkeyKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cb_hotkeyKey.FormattingEnabled = true;
-            this.cb_hotkeyKey.Location = new System.Drawing.Point(151, 17);
-            this.cb_hotkeyKey.Name = "cb_hotkeyKey";
-            this.cb_hotkeyKey.Size = new System.Drawing.Size(183, 21);
-            this.cb_hotkeyKey.TabIndex = 11;
-            this.cb_hotkeyKey.TabStop = false;
-            this.cb_hotkeyKey.SelectionChangeCommitted += new System.EventHandler(this.cb_hotkeyKey_SelectionChangeCommitted);
-            // 
-            // gb_hotkeyModifier
-            // 
-            this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModAlt);
-            this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModShift);
-            this.gb_hotkeyModifier.Controls.Add(this.chk_hotkeyModCtrl);
-            this.gb_hotkeyModifier.Location = new System.Drawing.Point(6, 9);
-            this.gb_hotkeyModifier.Name = "gb_hotkeyModifier";
-            this.gb_hotkeyModifier.Size = new System.Drawing.Size(139, 29);
-            this.gb_hotkeyModifier.TabIndex = 11;
-            this.gb_hotkeyModifier.TabStop = false;
-            // 
-            // chk_hotkeyModAlt
-            // 
-            this.chk_hotkeyModAlt.AutoCheck = false;
-            this.chk_hotkeyModAlt.AutoSize = true;
-            this.chk_hotkeyModAlt.Location = new System.Drawing.Point(100, 10);
-            this.chk_hotkeyModAlt.Name = "chk_hotkeyModAlt";
-            this.chk_hotkeyModAlt.Size = new System.Drawing.Size(37, 17);
-            this.chk_hotkeyModAlt.TabIndex = 0;
-            this.chk_hotkeyModAlt.TabStop = false;
-            this.chk_hotkeyModAlt.Text = "alt";
-            this.chk_hotkeyModAlt.UseVisualStyleBackColor = true;
-            this.chk_hotkeyModAlt.Click += new System.EventHandler(this.chk_hotkeyModAlt_Click);
-            // 
-            // chk_hotkeyModShift
-            // 
-            this.chk_hotkeyModShift.AutoCheck = false;
-            this.chk_hotkeyModShift.AutoSize = true;
-            this.chk_hotkeyModShift.Location = new System.Drawing.Point(49, 10);
-            this.chk_hotkeyModShift.Name = "chk_hotkeyModShift";
-            this.chk_hotkeyModShift.Size = new System.Drawing.Size(45, 17);
-            this.chk_hotkeyModShift.TabIndex = 0;
-            this.chk_hotkeyModShift.TabStop = false;
-            this.chk_hotkeyModShift.Text = "shift";
-            this.chk_hotkeyModShift.UseVisualStyleBackColor = true;
-            this.chk_hotkeyModShift.Click += new System.EventHandler(this.chk_hotkeyModShift_Click);
-            // 
-            // chk_hotkeyModCtrl
-            // 
-            this.chk_hotkeyModCtrl.AutoCheck = false;
-            this.chk_hotkeyModCtrl.AutoSize = true;
-            this.chk_hotkeyModCtrl.Checked = true;
-            this.chk_hotkeyModCtrl.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chk_hotkeyModCtrl.Location = new System.Drawing.Point(5, 10);
-            this.chk_hotkeyModCtrl.Name = "chk_hotkeyModCtrl";
-            this.chk_hotkeyModCtrl.Size = new System.Drawing.Size(40, 17);
-            this.chk_hotkeyModCtrl.TabIndex = 0;
-            this.chk_hotkeyModCtrl.TabStop = false;
-            this.chk_hotkeyModCtrl.Text = "ctrl";
-            this.chk_hotkeyModCtrl.UseVisualStyleBackColor = true;
-            this.chk_hotkeyModCtrl.Click += new System.EventHandler(this.chk_hotkeyModCtrl_Click);
-            // 
-            // lbl_website
-            // 
-            this.lbl_website.AutoSize = true;
-            this.lbl_website.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.lbl_website.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbl_website.Location = new System.Drawing.Point(273, 3);
-            this.lbl_website.Name = "lbl_website";
-            this.lbl_website.Size = new System.Drawing.Size(93, 13);
-            this.lbl_website.TabIndex = 12;
-            this.lbl_website.Text = "GitHub Repository";
-            this.lbl_website.Click += new System.EventHandler(this.lbl_website_Click);
-            // 
-            // notifyIcon
-            // 
-            this.notifyIcon.ContextMenuStrip = this.contextMenuStrip;
-            this.notifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon.Icon")));
-            this.notifyIcon.Text = "Fullscreenizer";
-            this.notifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon_MouseClick);
-            // 
-            // contextMenuStrip
-            // 
-            this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.lv_apps.FullRowSelect = true;
+			this.lv_apps.GridLines = true;
+			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+			this.lv_apps.HideSelection = false;
+			this.lv_apps.Location = new System.Drawing.Point(6, 14);
+			this.lv_apps.MultiSelect = false;
+			this.lv_apps.Name = "lv_apps";
+			this.lv_apps.Size = new System.Drawing.Size(328, 148);
+			this.lv_apps.Sorting = System.Windows.Forms.SortOrder.Ascending;
+			this.lv_apps.TabIndex = 0;
+			this.lv_apps.TabStop = false;
+			this.lv_apps.UseCompatibleStateImageBehavior = false;
+			this.lv_apps.View = System.Windows.Forms.View.Details;
+			// 
+			// ch_title
+			// 
+			this.ch_title.Text = "Title";
+			// 
+			// btn_fullscreenizeApp
+			// 
+			this.btn_fullscreenizeApp.Location = new System.Drawing.Point(6, 168);
+			this.btn_fullscreenizeApp.Name = "btn_fullscreenizeApp";
+			this.btn_fullscreenizeApp.Size = new System.Drawing.Size(76, 23);
+			this.btn_fullscreenizeApp.TabIndex = 3;
+			this.btn_fullscreenizeApp.TabStop = false;
+			this.btn_fullscreenizeApp.Text = "Fullscreenize";
+			this.btn_fullscreenizeApp.UseVisualStyleBackColor = true;
+			this.btn_fullscreenizeApp.Click += new System.EventHandler(this.btn_fullscreenizeApp_Click);
+			// 
+			// gb_apps
+			// 
+			this.gb_apps.Controls.Add(this.chk_moveWindow);
+			this.gb_apps.Controls.Add(this.chk_scaleToFit);
+			this.gb_apps.Controls.Add(this.btn_removeApp);
+			this.gb_apps.Controls.Add(this.lv_apps);
+			this.gb_apps.Controls.Add(this.btn_showAllApps);
+			this.gb_apps.Controls.Add(this.btn_fullscreenizeApp);
+			this.gb_apps.Location = new System.Drawing.Point(16, 36);
+			this.gb_apps.Name = "gb_apps";
+			this.gb_apps.Size = new System.Drawing.Size(342, 198);
+			this.gb_apps.TabIndex = 0;
+			this.gb_apps.TabStop = false;
+			// 
+			// chk_moveWindow
+			// 
+			this.chk_moveWindow.AutoSize = true;
+			this.chk_moveWindow.Checked = true;
+			this.chk_moveWindow.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chk_moveWindow.Location = new System.Drawing.Point(148, 172);
+			this.chk_moveWindow.Name = "chk_moveWindow";
+			this.chk_moveWindow.Size = new System.Drawing.Size(53, 17);
+			this.chk_moveWindow.TabIndex = 6;
+			this.chk_moveWindow.Text = "Move";
+			this.chk_moveWindow.UseVisualStyleBackColor = true;
+			this.chk_moveWindow.CheckedChanged += new System.EventHandler(this.chk_moveWindow_CheckedChanged);
+			// 
+			// chk_scaleToFit
+			// 
+			this.chk_scaleToFit.AutoSize = true;
+			this.chk_scaleToFit.Checked = true;
+			this.chk_scaleToFit.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chk_scaleToFit.Location = new System.Drawing.Point(88, 172);
+			this.chk_scaleToFit.Name = "chk_scaleToFit";
+			this.chk_scaleToFit.Size = new System.Drawing.Size(53, 17);
+			this.chk_scaleToFit.TabIndex = 5;
+			this.chk_scaleToFit.Text = "Scale";
+			this.chk_scaleToFit.UseVisualStyleBackColor = true;
+			this.chk_scaleToFit.CheckedChanged += new System.EventHandler(this.chk_scaleToFit_CheckedChanged);
+			// 
+			// btn_removeApp
+			// 
+			this.btn_removeApp.Location = new System.Drawing.Point(207, 168);
+			this.btn_removeApp.Name = "btn_removeApp";
+			this.btn_removeApp.Size = new System.Drawing.Size(57, 23);
+			this.btn_removeApp.TabIndex = 4;
+			this.btn_removeApp.Text = "Remove";
+			this.btn_removeApp.UseVisualStyleBackColor = true;
+			this.btn_removeApp.Click += new System.EventHandler(this.btn_removeApp_Click);
+			// 
+			// btn_showAllApps
+			// 
+			this.btn_showAllApps.Location = new System.Drawing.Point(270, 168);
+			this.btn_showAllApps.Name = "btn_showAllApps";
+			this.btn_showAllApps.Size = new System.Drawing.Size(64, 23);
+			this.btn_showAllApps.TabIndex = 3;
+			this.btn_showAllApps.TabStop = false;
+			this.btn_showAllApps.Text = "Show All";
+			this.btn_showAllApps.UseVisualStyleBackColor = true;
+			this.btn_showAllApps.Click += new System.EventHandler(this.btn_showAllApps_Click);
+			// 
+			// lbl_website
+			// 
+			this.lbl_website.AutoSize = true;
+			this.lbl_website.Cursor = System.Windows.Forms.Cursors.Hand;
+			this.lbl_website.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.lbl_website.Location = new System.Drawing.Point(273, 3);
+			this.lbl_website.Name = "lbl_website";
+			this.lbl_website.Size = new System.Drawing.Size(93, 13);
+			this.lbl_website.TabIndex = 12;
+			this.lbl_website.Text = "GitHub Repository";
+			this.lbl_website.Click += new System.EventHandler(this.lbl_website_Click);
+			// 
+			// notifyIcon
+			// 
+			this.notifyIcon.ContextMenuStrip = this.contextMenuStrip;
+			this.notifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon.Icon")));
+			this.notifyIcon.Text = "Fullscreenizer";
+			this.notifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon_MouseClick);
+			// 
+			// contextMenuStrip
+			// 
+			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItemShow,
             this.toolStripSeparator,
             this.toolStripMenuItemClose});
-            this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(104, 54);
-            // 
-            // toolStripMenuItemShow
-            // 
-            this.toolStripMenuItemShow.Name = "toolStripMenuItemShow";
-            this.toolStripMenuItemShow.Size = new System.Drawing.Size(103, 22);
-            this.toolStripMenuItemShow.Text = "Show";
-            this.toolStripMenuItemShow.Click += new System.EventHandler(this.toolStripMenuItemShow_Click);
-            // 
-            // toolStripSeparator
-            // 
-            this.toolStripSeparator.Name = "toolStripSeparator";
-            this.toolStripSeparator.Size = new System.Drawing.Size(100, 6);
-            // 
-            // toolStripMenuItemClose
-            // 
-            this.toolStripMenuItemClose.Name = "toolStripMenuItemClose";
-            this.toolStripMenuItemClose.Size = new System.Drawing.Size(103, 22);
-            this.toolStripMenuItemClose.Text = "Close";
-            this.toolStripMenuItemClose.Click += new System.EventHandler(this.toolStripMenuItemClose_Click);
-            // 
-            // chk_minimizeToTray
-            // 
-            this.chk_minimizeToTray.AutoSize = true;
-            this.chk_minimizeToTray.Checked = true;
-            this.chk_minimizeToTray.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chk_minimizeToTray.Location = new System.Drawing.Point(262, 23);
-            this.chk_minimizeToTray.Name = "chk_minimizeToTray";
-            this.chk_minimizeToTray.Size = new System.Drawing.Size(98, 17);
-            this.chk_minimizeToTray.TabIndex = 7;
-            this.chk_minimizeToTray.Text = "Minimize to tray";
-            this.chk_minimizeToTray.UseVisualStyleBackColor = true;
-            this.chk_minimizeToTray.CheckedChanged += new System.EventHandler(this.chk_minimizeToTray_CheckedChanged);
-            // 
-            // chk_LockCursor
-            // 
-            this.chk_lockCursor.AutoSize = true;
-            this.chk_lockCursor.Checked = true;
-            this.chk_lockCursor.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chk_lockCursor.Location = new System.Drawing.Point(167, 23);
-            this.chk_lockCursor.Name = "chk_lockCursor";
-            this.chk_lockCursor.Size = new System.Drawing.Size(82, 17);
-            this.chk_lockCursor.TabIndex = 13;
-            this.chk_lockCursor.Text = "Lock cursor";
-            this.chk_lockCursor.UseVisualStyleBackColor = true;
-            this.chk_lockCursor.CheckedChanged += new System.EventHandler(this.chk_lockCursor_CheckedChanged);
-            // 
-            // Fullscreenizer
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(369, 315);
-            this.Controls.Add(this.chk_lockCursor);
-            this.Controls.Add(this.chk_minimizeToTray);
-            this.Controls.Add(this.lbl_website);
-            this.Controls.Add(this.gb_hotkey);
-            this.Controls.Add(this.chk_enableHotkey);
-            this.Controls.Add(this.gb_apps);
-            this.Controls.Add(this.lbl_apps);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.Name = "Fullscreenizer";
-            this.Text = "Fullscreenizer";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Fullscreenizer_FormClosing);
-            this.Resize += new System.EventHandler(this.Fullscreenizer_Resize);
-            this.gb_apps.ResumeLayout(false);
-            this.gb_apps.PerformLayout();
-            this.gb_hotkey.ResumeLayout(false);
-            this.gb_hotkeyModifier.ResumeLayout(false);
-            this.gb_hotkeyModifier.PerformLayout();
-            this.contextMenuStrip.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.contextMenuStrip.Name = "contextMenuStrip";
+			this.contextMenuStrip.Size = new System.Drawing.Size(104, 54);
+			// 
+			// toolStripMenuItemShow
+			// 
+			this.toolStripMenuItemShow.Name = "toolStripMenuItemShow";
+			this.toolStripMenuItemShow.Size = new System.Drawing.Size(103, 22);
+			this.toolStripMenuItemShow.Text = "Show";
+			this.toolStripMenuItemShow.Click += new System.EventHandler(this.toolStripMenuItemShow_Click);
+			// 
+			// toolStripSeparator
+			// 
+			this.toolStripSeparator.Name = "toolStripSeparator";
+			this.toolStripSeparator.Size = new System.Drawing.Size(100, 6);
+			// 
+			// toolStripMenuItemClose
+			// 
+			this.toolStripMenuItemClose.Name = "toolStripMenuItemClose";
+			this.toolStripMenuItemClose.Size = new System.Drawing.Size(103, 22);
+			this.toolStripMenuItemClose.Text = "Close";
+			this.toolStripMenuItemClose.Click += new System.EventHandler(this.toolStripMenuItemClose_Click);
+			// 
+			// chk_minimizeToTray
+			// 
+			this.chk_minimizeToTray.AutoSize = true;
+			this.chk_minimizeToTray.Checked = true;
+			this.chk_minimizeToTray.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chk_minimizeToTray.Location = new System.Drawing.Point(262, 23);
+			this.chk_minimizeToTray.Name = "chk_minimizeToTray";
+			this.chk_minimizeToTray.Size = new System.Drawing.Size(98, 17);
+			this.chk_minimizeToTray.TabIndex = 7;
+			this.chk_minimizeToTray.Text = "Minimize to tray";
+			this.chk_minimizeToTray.UseVisualStyleBackColor = true;
+			this.chk_minimizeToTray.CheckedChanged += new System.EventHandler(this.chk_minimizeToTray_CheckedChanged);
+			// 
+			// chk_lockCursor
+			// 
+			this.chk_lockCursor.AutoSize = true;
+			this.chk_lockCursor.Checked = true;
+			this.chk_lockCursor.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chk_lockCursor.Location = new System.Drawing.Point(167, 23);
+			this.chk_lockCursor.Name = "chk_lockCursor";
+			this.chk_lockCursor.Size = new System.Drawing.Size(82, 17);
+			this.chk_lockCursor.TabIndex = 13;
+			this.chk_lockCursor.Text = "Lock cursor";
+			this.chk_lockCursor.UseVisualStyleBackColor = true;
+			this.chk_lockCursor.CheckedChanged += new System.EventHandler(this.chk_lockCursor_CheckedChanged);
+			// 
+			// chk_fullscreenizeEnableHotkey
+			// 
+			this.chk_fullscreenizeEnableHotkey.AutoCheck = false;
+			this.chk_fullscreenizeEnableHotkey.AutoSize = true;
+			this.chk_fullscreenizeEnableHotkey.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.chk_fullscreenizeEnableHotkey.Location = new System.Drawing.Point(16, 236);
+			this.chk_fullscreenizeEnableHotkey.Name = "chk_fullscreenizeEnableHotkey";
+			this.chk_fullscreenizeEnableHotkey.Size = new System.Drawing.Size(202, 28);
+			this.chk_fullscreenizeEnableHotkey.TabIndex = 9;
+			this.chk_fullscreenizeEnableHotkey.TabStop = false;
+			this.chk_fullscreenizeEnableHotkey.Text = "Fullscreenize hotkey";
+			this.chk_fullscreenizeEnableHotkey.UseVisualStyleBackColor = true;
+			this.chk_fullscreenizeEnableHotkey.Click += new System.EventHandler(this.chk_fullscreenizeEnableHotkey_Click);
+			// 
+			// gb_hotkeyModifier
+			// 
+			this.gb_hotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModAlt);
+			this.gb_hotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModShift);
+			this.gb_hotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModCtrl);
+			this.gb_hotkeyModifier.Location = new System.Drawing.Point(6, 9);
+			this.gb_hotkeyModifier.Name = "gb_hotkeyModifier";
+			this.gb_hotkeyModifier.Size = new System.Drawing.Size(139, 29);
+			this.gb_hotkeyModifier.TabIndex = 11;
+			this.gb_hotkeyModifier.TabStop = false;
+			// 
+			// chk_fullscreenizeHotkeyModAlt
+			// 
+			this.chk_fullscreenizeHotkeyModAlt.AutoCheck = false;
+			this.chk_fullscreenizeHotkeyModAlt.AutoSize = true;
+			this.chk_fullscreenizeHotkeyModAlt.Location = new System.Drawing.Point(100, 10);
+			this.chk_fullscreenizeHotkeyModAlt.Name = "chk_fullscreenizeHotkeyModAlt";
+			this.chk_fullscreenizeHotkeyModAlt.Size = new System.Drawing.Size(37, 17);
+			this.chk_fullscreenizeHotkeyModAlt.TabIndex = 0;
+			this.chk_fullscreenizeHotkeyModAlt.TabStop = false;
+			this.chk_fullscreenizeHotkeyModAlt.Text = "alt";
+			this.chk_fullscreenizeHotkeyModAlt.UseVisualStyleBackColor = true;
+			this.chk_fullscreenizeHotkeyModAlt.Click += new System.EventHandler(this.chk_fullscreenizeHotkeyModAlt_Click);
+			// 
+			// chk_fullscreenizeHotkeyModShift
+			// 
+			this.chk_fullscreenizeHotkeyModShift.AutoCheck = false;
+			this.chk_fullscreenizeHotkeyModShift.AutoSize = true;
+			this.chk_fullscreenizeHotkeyModShift.Location = new System.Drawing.Point(49, 10);
+			this.chk_fullscreenizeHotkeyModShift.Name = "chk_fullscreenizeHotkeyModShift";
+			this.chk_fullscreenizeHotkeyModShift.Size = new System.Drawing.Size(45, 17);
+			this.chk_fullscreenizeHotkeyModShift.TabIndex = 0;
+			this.chk_fullscreenizeHotkeyModShift.TabStop = false;
+			this.chk_fullscreenizeHotkeyModShift.Text = "shift";
+			this.chk_fullscreenizeHotkeyModShift.UseVisualStyleBackColor = true;
+			this.chk_fullscreenizeHotkeyModShift.Click += new System.EventHandler(this.chk_fullscreenizeHotkeyModShift_Click);
+			// 
+			// chk_fullscreenizeHotkeyModCtrl
+			// 
+			this.chk_fullscreenizeHotkeyModCtrl.AutoCheck = false;
+			this.chk_fullscreenizeHotkeyModCtrl.AutoSize = true;
+			this.chk_fullscreenizeHotkeyModCtrl.Checked = true;
+			this.chk_fullscreenizeHotkeyModCtrl.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chk_fullscreenizeHotkeyModCtrl.Location = new System.Drawing.Point(5, 10);
+			this.chk_fullscreenizeHotkeyModCtrl.Name = "chk_fullscreenizeHotkeyModCtrl";
+			this.chk_fullscreenizeHotkeyModCtrl.Size = new System.Drawing.Size(40, 17);
+			this.chk_fullscreenizeHotkeyModCtrl.TabIndex = 0;
+			this.chk_fullscreenizeHotkeyModCtrl.TabStop = false;
+			this.chk_fullscreenizeHotkeyModCtrl.Text = "ctrl";
+			this.chk_fullscreenizeHotkeyModCtrl.UseVisualStyleBackColor = true;
+			this.chk_fullscreenizeHotkeyModCtrl.Click += new System.EventHandler(this.chk_fullscreenizeHotkeyModCtrl_Click);
+			// 
+			// cb_fullscreenizeHotkeyKey
+			// 
+			this.cb_fullscreenizeHotkeyKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cb_fullscreenizeHotkeyKey.FormattingEnabled = true;
+			this.cb_fullscreenizeHotkeyKey.Location = new System.Drawing.Point(151, 17);
+			this.cb_fullscreenizeHotkeyKey.Name = "cb_fullscreenizeHotkeyKey";
+			this.cb_fullscreenizeHotkeyKey.Size = new System.Drawing.Size(183, 21);
+			this.cb_fullscreenizeHotkeyKey.TabIndex = 11;
+			this.cb_fullscreenizeHotkeyKey.TabStop = false;
+			this.cb_fullscreenizeHotkeyKey.SelectionChangeCommitted += new System.EventHandler(this.cb_fullscreenizeHotkeyKey_SelectionChangeCommitted);
+			// 
+			// gb_fullscreenizeHotkey
+			// 
+			this.gb_fullscreenizeHotkey.Controls.Add(this.cb_fullscreenizeHotkeyKey);
+			this.gb_fullscreenizeHotkey.Controls.Add(this.gb_hotkeyModifier);
+			this.gb_fullscreenizeHotkey.Location = new System.Drawing.Point(16, 261);
+			this.gb_fullscreenizeHotkey.Name = "gb_fullscreenizeHotkey";
+			this.gb_fullscreenizeHotkey.Size = new System.Drawing.Size(342, 47);
+			this.gb_fullscreenizeHotkey.TabIndex = 10;
+			this.gb_fullscreenizeHotkey.TabStop = false;
+			// 
+			// gb_lockCursorHotkey
+			// 
+			this.gb_lockCursorHotkey.Controls.Add(this.cb_lockCursorHotkeyKey);
+			this.gb_lockCursorHotkey.Controls.Add(this.groupBox2);
+			this.gb_lockCursorHotkey.Location = new System.Drawing.Point(16, 335);
+			this.gb_lockCursorHotkey.Name = "gb_lockCursorHotkey";
+			this.gb_lockCursorHotkey.Size = new System.Drawing.Size(342, 47);
+			this.gb_lockCursorHotkey.TabIndex = 15;
+			this.gb_lockCursorHotkey.TabStop = false;
+			// 
+			// cb_lockCursorHotkeyKey
+			// 
+			this.cb_lockCursorHotkeyKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cb_lockCursorHotkeyKey.FormattingEnabled = true;
+			this.cb_lockCursorHotkeyKey.Location = new System.Drawing.Point(151, 17);
+			this.cb_lockCursorHotkeyKey.Name = "cb_lockCursorHotkeyKey";
+			this.cb_lockCursorHotkeyKey.Size = new System.Drawing.Size(183, 21);
+			this.cb_lockCursorHotkeyKey.TabIndex = 11;
+			this.cb_lockCursorHotkeyKey.TabStop = false;
+			this.cb_lockCursorHotkeyKey.SelectionChangeCommitted += new System.EventHandler(this.cb_lockCursorHotkeyKey_SelectionChangeCommitted);
+			// 
+			// groupBox2
+			// 
+			this.groupBox2.Controls.Add(this.chk_lockCursorHotkeyModAlt);
+			this.groupBox2.Controls.Add(this.chk_lockCursorHotkeyModShift);
+			this.groupBox2.Controls.Add(this.chk_lockCursorHotkeyModCtrl);
+			this.groupBox2.Location = new System.Drawing.Point(6, 9);
+			this.groupBox2.Name = "groupBox2";
+			this.groupBox2.Size = new System.Drawing.Size(139, 29);
+			this.groupBox2.TabIndex = 11;
+			this.groupBox2.TabStop = false;
+			// 
+			// chk_lockCursorHotkeyModAlt
+			// 
+			this.chk_lockCursorHotkeyModAlt.AutoCheck = false;
+			this.chk_lockCursorHotkeyModAlt.AutoSize = true;
+			this.chk_lockCursorHotkeyModAlt.Location = new System.Drawing.Point(100, 10);
+			this.chk_lockCursorHotkeyModAlt.Name = "chk_lockCursorHotkeyModAlt";
+			this.chk_lockCursorHotkeyModAlt.Size = new System.Drawing.Size(37, 17);
+			this.chk_lockCursorHotkeyModAlt.TabIndex = 0;
+			this.chk_lockCursorHotkeyModAlt.TabStop = false;
+			this.chk_lockCursorHotkeyModAlt.Text = "alt";
+			this.chk_lockCursorHotkeyModAlt.UseVisualStyleBackColor = true;
+			this.chk_lockCursorHotkeyModAlt.Click += new System.EventHandler(this.chk_lockCursorHotkeyModAlt_Click);
+			// 
+			// chk_lockCursorHotkeyModShift
+			// 
+			this.chk_lockCursorHotkeyModShift.AutoCheck = false;
+			this.chk_lockCursorHotkeyModShift.AutoSize = true;
+			this.chk_lockCursorHotkeyModShift.Location = new System.Drawing.Point(49, 10);
+			this.chk_lockCursorHotkeyModShift.Name = "chk_lockCursorHotkeyModShift";
+			this.chk_lockCursorHotkeyModShift.Size = new System.Drawing.Size(45, 17);
+			this.chk_lockCursorHotkeyModShift.TabIndex = 0;
+			this.chk_lockCursorHotkeyModShift.TabStop = false;
+			this.chk_lockCursorHotkeyModShift.Text = "shift";
+			this.chk_lockCursorHotkeyModShift.UseVisualStyleBackColor = true;
+			this.chk_lockCursorHotkeyModShift.Click += new System.EventHandler(this.chk_lockCursorHotkeyModShift_Click);
+			// 
+			// chk_lockCursorHotkeyModCtrl
+			// 
+			this.chk_lockCursorHotkeyModCtrl.AutoCheck = false;
+			this.chk_lockCursorHotkeyModCtrl.AutoSize = true;
+			this.chk_lockCursorHotkeyModCtrl.Checked = true;
+			this.chk_lockCursorHotkeyModCtrl.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chk_lockCursorHotkeyModCtrl.Location = new System.Drawing.Point(5, 10);
+			this.chk_lockCursorHotkeyModCtrl.Name = "chk_lockCursorHotkeyModCtrl";
+			this.chk_lockCursorHotkeyModCtrl.Size = new System.Drawing.Size(40, 17);
+			this.chk_lockCursorHotkeyModCtrl.TabIndex = 0;
+			this.chk_lockCursorHotkeyModCtrl.TabStop = false;
+			this.chk_lockCursorHotkeyModCtrl.Text = "ctrl";
+			this.chk_lockCursorHotkeyModCtrl.UseVisualStyleBackColor = true;
+			this.chk_lockCursorHotkeyModCtrl.Click += new System.EventHandler(this.chk_lockCursorHotkeyModCtrl_Click);
+			// 
+			// chk_lockCursorEnableHotkey
+			// 
+			this.chk_lockCursorEnableHotkey.AutoCheck = false;
+			this.chk_lockCursorEnableHotkey.AutoSize = true;
+			this.chk_lockCursorEnableHotkey.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.chk_lockCursorEnableHotkey.Location = new System.Drawing.Point(16, 310);
+			this.chk_lockCursorEnableHotkey.Name = "chk_lockCursorEnableHotkey";
+			this.chk_lockCursorEnableHotkey.Size = new System.Drawing.Size(187, 28);
+			this.chk_lockCursorEnableHotkey.TabIndex = 14;
+			this.chk_lockCursorEnableHotkey.TabStop = false;
+			this.chk_lockCursorEnableHotkey.Text = "Lock cursor hotkey";
+			this.chk_lockCursorEnableHotkey.UseVisualStyleBackColor = true;
+			this.chk_lockCursorEnableHotkey.Click += new System.EventHandler(this.chk_lockCursorEnableHotkey_Click);
+			// 
+			// Fullscreenizer
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(369, 387);
+			this.Controls.Add(this.gb_lockCursorHotkey);
+			this.Controls.Add(this.chk_lockCursorEnableHotkey);
+			this.Controls.Add(this.chk_lockCursor);
+			this.Controls.Add(this.chk_minimizeToTray);
+			this.Controls.Add(this.lbl_website);
+			this.Controls.Add(this.gb_fullscreenizeHotkey);
+			this.Controls.Add(this.chk_fullscreenizeEnableHotkey);
+			this.Controls.Add(this.gb_apps);
+			this.Controls.Add(this.lbl_apps);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.MaximizeBox = false;
+			this.Name = "Fullscreenizer";
+			this.Text = "Fullscreenizer";
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Fullscreenizer_FormClosing);
+			this.Resize += new System.EventHandler(this.Fullscreenizer_Resize);
+			this.gb_apps.ResumeLayout(false);
+			this.gb_apps.PerformLayout();
+			this.contextMenuStrip.ResumeLayout(false);
+			this.gb_hotkeyModifier.ResumeLayout(false);
+			this.gb_hotkeyModifier.PerformLayout();
+			this.gb_fullscreenizeHotkey.ResumeLayout(false);
+			this.gb_lockCursorHotkey.ResumeLayout(false);
+			this.groupBox2.ResumeLayout(false);
+			this.groupBox2.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
 		}
 
@@ -360,13 +461,6 @@
 		private System.Windows.Forms.ListView lv_apps;
 		private System.Windows.Forms.Button btn_fullscreenizeApp;
 		private System.Windows.Forms.GroupBox gb_apps;
-		private System.Windows.Forms.CheckBox chk_enableHotkey;
-		private System.Windows.Forms.GroupBox gb_hotkey;
-		private System.Windows.Forms.ComboBox cb_hotkeyKey;
-		private System.Windows.Forms.GroupBox gb_hotkeyModifier;
-		private System.Windows.Forms.CheckBox chk_hotkeyModAlt;
-		private System.Windows.Forms.CheckBox chk_hotkeyModShift;
-		private System.Windows.Forms.CheckBox chk_hotkeyModCtrl;
 		private System.Windows.Forms.Label lbl_website;
 		private System.Windows.Forms.ColumnHeader ch_title;
 		private System.Windows.Forms.Button btn_showAllApps;
@@ -380,6 +474,20 @@
 		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemClose;
 		private System.Windows.Forms.CheckBox chk_minimizeToTray;
         private System.Windows.Forms.CheckBox chk_lockCursor;
+        private System.Windows.Forms.CheckBox chk_fullscreenizeEnableHotkey;
+        private System.Windows.Forms.GroupBox gb_hotkeyModifier;
+        private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModAlt;
+        private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModShift;
+        private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModCtrl;
+        private System.Windows.Forms.ComboBox cb_fullscreenizeHotkeyKey;
+        private System.Windows.Forms.GroupBox gb_fullscreenizeHotkey;
+        private System.Windows.Forms.GroupBox gb_lockCursorHotkey;
+        private System.Windows.Forms.ComboBox cb_lockCursorHotkeyKey;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModAlt;
+        private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModShift;
+        private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModCtrl;
+        private System.Windows.Forms.CheckBox chk_lockCursorEnableHotkey;
     }
 }
 

--- a/Fullscreenizer/Fullscreenizer.Designer.cs
+++ b/Fullscreenizer/Fullscreenizer.Designer.cs
@@ -248,8 +248,9 @@
 			// 
 			// chk_fullscreenizeEnableHotkey
 			// 
-			this.chk_fullscreenizeEnableHotkey.AutoCheck = false;
 			this.chk_fullscreenizeEnableHotkey.AutoSize = true;
+			this.chk_fullscreenizeEnableHotkey.Checked = true;
+			this.chk_fullscreenizeEnableHotkey.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.chk_fullscreenizeEnableHotkey.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.chk_fullscreenizeEnableHotkey.Location = new System.Drawing.Point(16, 236);
 			this.chk_fullscreenizeEnableHotkey.Name = "chk_fullscreenizeEnableHotkey";
@@ -258,7 +259,7 @@
 			this.chk_fullscreenizeEnableHotkey.TabStop = false;
 			this.chk_fullscreenizeEnableHotkey.Text = "Fullscreenize hotkey";
 			this.chk_fullscreenizeEnableHotkey.UseVisualStyleBackColor = true;
-			this.chk_fullscreenizeEnableHotkey.Click += new System.EventHandler(this.chk_fullscreenizeEnableHotkey_Click);
+			this.chk_fullscreenizeEnableHotkey.CheckedChanged += new System.EventHandler(this.chk_fullscreenizeEnableHotkey_CheckedChanged);
 			// 
 			// gb_fullscreenizeHotkeyModifier
 			// 
@@ -408,8 +409,9 @@
 			// 
 			// chk_lockCursorEnableHotkey
 			// 
-			this.chk_lockCursorEnableHotkey.AutoCheck = false;
 			this.chk_lockCursorEnableHotkey.AutoSize = true;
+			this.chk_lockCursorEnableHotkey.Checked = true;
+			this.chk_lockCursorEnableHotkey.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.chk_lockCursorEnableHotkey.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.chk_lockCursorEnableHotkey.Location = new System.Drawing.Point(16, 310);
 			this.chk_lockCursorEnableHotkey.Name = "chk_lockCursorEnableHotkey";
@@ -418,7 +420,7 @@
 			this.chk_lockCursorEnableHotkey.TabStop = false;
 			this.chk_lockCursorEnableHotkey.Text = "Lock cursor hotkey";
 			this.chk_lockCursorEnableHotkey.UseVisualStyleBackColor = true;
-			this.chk_lockCursorEnableHotkey.Click += new System.EventHandler(this.chk_lockCursorEnableHotkey_Click);
+			this.chk_lockCursorEnableHotkey.CheckedChanged += new System.EventHandler(this.chk_lockCursorEnableHotkey_CheckedChanged);
 			// 
 			// Fullscreenizer
 			// 

--- a/Fullscreenizer/Fullscreenizer.Designer.cs
+++ b/Fullscreenizer/Fullscreenizer.Designer.cs
@@ -48,7 +48,7 @@
 			this.chk_minimizeToTray = new System.Windows.Forms.CheckBox();
 			this.chk_lockCursor = new System.Windows.Forms.CheckBox();
 			this.chk_fullscreenizeEnableHotkey = new System.Windows.Forms.CheckBox();
-			this.gb_hotkeyModifier = new System.Windows.Forms.GroupBox();
+			this.gb_fullscreenizeHotkeyModifier = new System.Windows.Forms.GroupBox();
 			this.chk_fullscreenizeHotkeyModAlt = new System.Windows.Forms.CheckBox();
 			this.chk_fullscreenizeHotkeyModShift = new System.Windows.Forms.CheckBox();
 			this.chk_fullscreenizeHotkeyModCtrl = new System.Windows.Forms.CheckBox();
@@ -56,17 +56,17 @@
 			this.gb_fullscreenizeHotkey = new System.Windows.Forms.GroupBox();
 			this.gb_lockCursorHotkey = new System.Windows.Forms.GroupBox();
 			this.cb_lockCursorHotkeyKey = new System.Windows.Forms.ComboBox();
-			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.gb_lockCursorHotkeyModifier = new System.Windows.Forms.GroupBox();
 			this.chk_lockCursorHotkeyModAlt = new System.Windows.Forms.CheckBox();
 			this.chk_lockCursorHotkeyModShift = new System.Windows.Forms.CheckBox();
 			this.chk_lockCursorHotkeyModCtrl = new System.Windows.Forms.CheckBox();
 			this.chk_lockCursorEnableHotkey = new System.Windows.Forms.CheckBox();
 			this.gb_apps.SuspendLayout();
 			this.contextMenuStrip.SuspendLayout();
-			this.gb_hotkeyModifier.SuspendLayout();
+			this.gb_fullscreenizeHotkeyModifier.SuspendLayout();
 			this.gb_fullscreenizeHotkey.SuspendLayout();
 			this.gb_lockCursorHotkey.SuspendLayout();
-			this.groupBox2.SuspendLayout();
+			this.gb_lockCursorHotkeyModifier.SuspendLayout();
 			this.SuspendLayout();
 			// 
 			// lbl_apps
@@ -260,16 +260,16 @@
 			this.chk_fullscreenizeEnableHotkey.UseVisualStyleBackColor = true;
 			this.chk_fullscreenizeEnableHotkey.Click += new System.EventHandler(this.chk_fullscreenizeEnableHotkey_Click);
 			// 
-			// gb_hotkeyModifier
+			// gb_fullscreenizeHotkeyModifier
 			// 
-			this.gb_hotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModAlt);
-			this.gb_hotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModShift);
-			this.gb_hotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModCtrl);
-			this.gb_hotkeyModifier.Location = new System.Drawing.Point(6, 9);
-			this.gb_hotkeyModifier.Name = "gb_hotkeyModifier";
-			this.gb_hotkeyModifier.Size = new System.Drawing.Size(139, 29);
-			this.gb_hotkeyModifier.TabIndex = 11;
-			this.gb_hotkeyModifier.TabStop = false;
+			this.gb_fullscreenizeHotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModAlt);
+			this.gb_fullscreenizeHotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModShift);
+			this.gb_fullscreenizeHotkeyModifier.Controls.Add(this.chk_fullscreenizeHotkeyModCtrl);
+			this.gb_fullscreenizeHotkeyModifier.Location = new System.Drawing.Point(6, 9);
+			this.gb_fullscreenizeHotkeyModifier.Name = "gb_fullscreenizeHotkeyModifier";
+			this.gb_fullscreenizeHotkeyModifier.Size = new System.Drawing.Size(139, 29);
+			this.gb_fullscreenizeHotkeyModifier.TabIndex = 11;
+			this.gb_fullscreenizeHotkeyModifier.TabStop = false;
 			// 
 			// chk_fullscreenizeHotkeyModAlt
 			// 
@@ -316,7 +316,7 @@
 			// 
 			this.cb_fullscreenizeHotkeyKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.cb_fullscreenizeHotkeyKey.FormattingEnabled = true;
-			this.cb_fullscreenizeHotkeyKey.Location = new System.Drawing.Point(151, 17);
+			this.cb_fullscreenizeHotkeyKey.Location = new System.Drawing.Point(151, 16);
 			this.cb_fullscreenizeHotkeyKey.Name = "cb_fullscreenizeHotkeyKey";
 			this.cb_fullscreenizeHotkeyKey.Size = new System.Drawing.Size(183, 21);
 			this.cb_fullscreenizeHotkeyKey.TabIndex = 11;
@@ -326,7 +326,7 @@
 			// gb_fullscreenizeHotkey
 			// 
 			this.gb_fullscreenizeHotkey.Controls.Add(this.cb_fullscreenizeHotkeyKey);
-			this.gb_fullscreenizeHotkey.Controls.Add(this.gb_hotkeyModifier);
+			this.gb_fullscreenizeHotkey.Controls.Add(this.gb_fullscreenizeHotkeyModifier);
 			this.gb_fullscreenizeHotkey.Location = new System.Drawing.Point(16, 261);
 			this.gb_fullscreenizeHotkey.Name = "gb_fullscreenizeHotkey";
 			this.gb_fullscreenizeHotkey.Size = new System.Drawing.Size(342, 47);
@@ -336,7 +336,7 @@
 			// gb_lockCursorHotkey
 			// 
 			this.gb_lockCursorHotkey.Controls.Add(this.cb_lockCursorHotkeyKey);
-			this.gb_lockCursorHotkey.Controls.Add(this.groupBox2);
+			this.gb_lockCursorHotkey.Controls.Add(this.gb_lockCursorHotkeyModifier);
 			this.gb_lockCursorHotkey.Location = new System.Drawing.Point(16, 335);
 			this.gb_lockCursorHotkey.Name = "gb_lockCursorHotkey";
 			this.gb_lockCursorHotkey.Size = new System.Drawing.Size(342, 47);
@@ -347,23 +347,23 @@
 			// 
 			this.cb_lockCursorHotkeyKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.cb_lockCursorHotkeyKey.FormattingEnabled = true;
-			this.cb_lockCursorHotkeyKey.Location = new System.Drawing.Point(151, 17);
+			this.cb_lockCursorHotkeyKey.Location = new System.Drawing.Point(151, 16);
 			this.cb_lockCursorHotkeyKey.Name = "cb_lockCursorHotkeyKey";
 			this.cb_lockCursorHotkeyKey.Size = new System.Drawing.Size(183, 21);
 			this.cb_lockCursorHotkeyKey.TabIndex = 11;
 			this.cb_lockCursorHotkeyKey.TabStop = false;
 			this.cb_lockCursorHotkeyKey.SelectionChangeCommitted += new System.EventHandler(this.cb_lockCursorHotkeyKey_SelectionChangeCommitted);
 			// 
-			// groupBox2
+			// gb_lockCursorHotkeyModifier
 			// 
-			this.groupBox2.Controls.Add(this.chk_lockCursorHotkeyModAlt);
-			this.groupBox2.Controls.Add(this.chk_lockCursorHotkeyModShift);
-			this.groupBox2.Controls.Add(this.chk_lockCursorHotkeyModCtrl);
-			this.groupBox2.Location = new System.Drawing.Point(6, 9);
-			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(139, 29);
-			this.groupBox2.TabIndex = 11;
-			this.groupBox2.TabStop = false;
+			this.gb_lockCursorHotkeyModifier.Controls.Add(this.chk_lockCursorHotkeyModAlt);
+			this.gb_lockCursorHotkeyModifier.Controls.Add(this.chk_lockCursorHotkeyModShift);
+			this.gb_lockCursorHotkeyModifier.Controls.Add(this.chk_lockCursorHotkeyModCtrl);
+			this.gb_lockCursorHotkeyModifier.Location = new System.Drawing.Point(6, 9);
+			this.gb_lockCursorHotkeyModifier.Name = "gb_lockCursorHotkeyModifier";
+			this.gb_lockCursorHotkeyModifier.Size = new System.Drawing.Size(139, 29);
+			this.gb_lockCursorHotkeyModifier.TabIndex = 11;
+			this.gb_lockCursorHotkeyModifier.TabStop = false;
 			// 
 			// chk_lockCursorHotkeyModAlt
 			// 
@@ -444,12 +444,12 @@
 			this.gb_apps.ResumeLayout(false);
 			this.gb_apps.PerformLayout();
 			this.contextMenuStrip.ResumeLayout(false);
-			this.gb_hotkeyModifier.ResumeLayout(false);
-			this.gb_hotkeyModifier.PerformLayout();
+			this.gb_fullscreenizeHotkeyModifier.ResumeLayout(false);
+			this.gb_fullscreenizeHotkeyModifier.PerformLayout();
 			this.gb_fullscreenizeHotkey.ResumeLayout(false);
 			this.gb_lockCursorHotkey.ResumeLayout(false);
-			this.groupBox2.ResumeLayout(false);
-			this.groupBox2.PerformLayout();
+			this.gb_lockCursorHotkeyModifier.ResumeLayout(false);
+			this.gb_lockCursorHotkeyModifier.PerformLayout();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
@@ -475,7 +475,7 @@
 		private System.Windows.Forms.CheckBox chk_minimizeToTray;
         private System.Windows.Forms.CheckBox chk_lockCursor;
         private System.Windows.Forms.CheckBox chk_fullscreenizeEnableHotkey;
-        private System.Windows.Forms.GroupBox gb_hotkeyModifier;
+        private System.Windows.Forms.GroupBox gb_fullscreenizeHotkeyModifier;
         private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModAlt;
         private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModShift;
         private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModCtrl;
@@ -483,7 +483,7 @@
         private System.Windows.Forms.GroupBox gb_fullscreenizeHotkey;
         private System.Windows.Forms.GroupBox gb_lockCursorHotkey;
         private System.Windows.Forms.ComboBox cb_lockCursorHotkeyKey;
-        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.GroupBox gb_lockCursorHotkeyModifier;
         private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModAlt;
         private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModShift;
         private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModCtrl;

--- a/Fullscreenizer/Fullscreenizer.Designer.cs
+++ b/Fullscreenizer/Fullscreenizer.Designer.cs
@@ -82,7 +82,7 @@
 			// lv_apps
 			// 
 			this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.ch_title});
+			this.ch_title});
 			this.lv_apps.FullRowSelect = true;
 			this.lv_apps.GridLines = true;
 			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
@@ -195,9 +195,9 @@
 			// contextMenuStrip
 			// 
 			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemShow,
-            this.toolStripSeparator,
-            this.toolStripMenuItemClose});
+			this.toolStripMenuItemShow,
+			this.toolStripSeparator,
+			this.toolStripMenuItemClose});
 			this.contextMenuStrip.Name = "contextMenuStrip";
 			this.contextMenuStrip.Size = new System.Drawing.Size(104, 54);
 			// 
@@ -475,21 +475,21 @@
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator;
 		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemClose;
 		private System.Windows.Forms.CheckBox chk_minimizeToTray;
-        private System.Windows.Forms.CheckBox chk_lockCursor;
-        private System.Windows.Forms.CheckBox chk_fullscreenizeEnableHotkey;
-        private System.Windows.Forms.GroupBox gb_fullscreenizeHotkeyModifier;
-        private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModAlt;
-        private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModShift;
-        private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModCtrl;
-        private System.Windows.Forms.ComboBox cb_fullscreenizeHotkeyKey;
-        private System.Windows.Forms.GroupBox gb_fullscreenizeHotkey;
-        private System.Windows.Forms.GroupBox gb_lockCursorHotkey;
-        private System.Windows.Forms.ComboBox cb_lockCursorHotkeyKey;
-        private System.Windows.Forms.GroupBox gb_lockCursorHotkeyModifier;
-        private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModAlt;
-        private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModShift;
-        private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModCtrl;
-        private System.Windows.Forms.CheckBox chk_lockCursorEnableHotkey;
-    }
+		private System.Windows.Forms.CheckBox chk_lockCursor;
+		private System.Windows.Forms.CheckBox chk_fullscreenizeEnableHotkey;
+		private System.Windows.Forms.GroupBox gb_fullscreenizeHotkeyModifier;
+		private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModAlt;
+		private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModShift;
+		private System.Windows.Forms.CheckBox chk_fullscreenizeHotkeyModCtrl;
+		private System.Windows.Forms.ComboBox cb_fullscreenizeHotkeyKey;
+		private System.Windows.Forms.GroupBox gb_fullscreenizeHotkey;
+		private System.Windows.Forms.GroupBox gb_lockCursorHotkey;
+		private System.Windows.Forms.ComboBox cb_lockCursorHotkeyKey;
+		private System.Windows.Forms.GroupBox gb_lockCursorHotkeyModifier;
+		private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModAlt;
+		private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModShift;
+		private System.Windows.Forms.CheckBox chk_lockCursorHotkeyModCtrl;
+		private System.Windows.Forms.CheckBox chk_lockCursorEnableHotkey;
+	}
 }
 

--- a/Fullscreenizer/Fullscreenizer.Designer.cs
+++ b/Fullscreenizer/Fullscreenizer.Designer.cs
@@ -82,7 +82,7 @@
 			// lv_apps
 			// 
 			this.lv_apps.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-			this.ch_title});
+            this.ch_title});
 			this.lv_apps.FullRowSelect = true;
 			this.lv_apps.GridLines = true;
 			this.lv_apps.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
@@ -96,6 +96,7 @@
 			this.lv_apps.TabStop = false;
 			this.lv_apps.UseCompatibleStateImageBehavior = false;
 			this.lv_apps.View = System.Windows.Forms.View.Details;
+			this.lv_apps.DoubleClick += new System.EventHandler(this.lv_apps_DoubleClick);
 			// 
 			// ch_title
 			// 
@@ -195,9 +196,9 @@
 			// contextMenuStrip
 			// 
 			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripMenuItemShow,
-			this.toolStripSeparator,
-			this.toolStripMenuItemClose});
+            this.toolStripMenuItemShow,
+            this.toolStripSeparator,
+            this.toolStripMenuItemClose});
 			this.contextMenuStrip.Name = "contextMenuStrip";
 			this.contextMenuStrip.Size = new System.Drawing.Size(104, 54);
 			// 

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -212,7 +212,7 @@ namespace Fullscreenizer
 
 		private void cb_lockCursorHotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
 		{
-			_config.LockCursorKeyFlags = (Keys)cb_fullscreenizeHotkeyKey.SelectedItem;
+			_config.LockCursorKeyFlags = (Keys)cb_lockCursorHotkeyKey.SelectedItem;
 			if( _config.LockCursorHotkeyActive )
 			{
 				enableHotkey();

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -63,28 +63,28 @@ namespace Fullscreenizer
 			_canFullscreenizeTimer.Start();
 		}
 
-		void Fullscreenizer_FormClosing(object sender, FormClosingEventArgs e)
+		private void Fullscreenizer_FormClosing(object sender, FormClosingEventArgs e)
 		{
 			_config.writeConfigFile();
 		}
 
-		void Fullscreenizer_Resize(object sender, EventArgs e)
+		private void Fullscreenizer_Resize(object sender, EventArgs e)
 		{
-			if (WindowState == FormWindowState.Minimized && chk_minimizeToTray.Checked)
+			if( WindowState == FormWindowState.Minimized && chk_minimizeToTray.Checked )
 			{
 				Hide();
 				notifyIcon.Visible = true;
 			}
 		}
 
-		void chk_fullscreenizeEnableHotkey_Click(object sender, EventArgs e)
+		private void chk_fullscreenizeEnableHotkey_CheckedChanged(object sender, EventArgs e)
 		{
-			// Flip the hotkey.
-			chk_fullscreenizeEnableHotkey.Checked = !chk_fullscreenizeEnableHotkey.Checked;
+			// Flip the groupbox.
+			gb_fullscreenizeHotkey.Enabled = chk_fullscreenizeEnableHotkey.Checked;
 			// Update the config.
 			_config.FullscreenizeHotkeyActive = chk_fullscreenizeEnableHotkey.Checked;
 			// Enable or disable based on status.
-			if (chk_fullscreenizeEnableHotkey.Checked)
+			if( chk_fullscreenizeEnableHotkey.Checked )
 			{
 				enableHotkey();
 			}
@@ -94,7 +94,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void chk_fullscreenizeHotkeyModCtrl_Click(object sender, EventArgs e)
+		private void chk_fullscreenizeHotkeyModCtrl_Click(object sender, EventArgs e)
 		{
 			if( !chk_fullscreenizeHotkeyModShift.Checked && !chk_fullscreenizeHotkeyModAlt.Checked )
 			{
@@ -109,7 +109,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void chk_fullscreenizeHotkeyModShift_Click(object sender, EventArgs e)
+		private void chk_fullscreenizeHotkeyModShift_Click(object sender, EventArgs e)
 		{
 			if( !chk_fullscreenizeHotkeyModCtrl.Checked && !chk_fullscreenizeHotkeyModAlt.Checked )
 			{
@@ -124,7 +124,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void chk_fullscreenizeHotkeyModAlt_Click(object sender, EventArgs e)
+		private void chk_fullscreenizeHotkeyModAlt_Click(object sender, EventArgs e)
 		{
 			if( !chk_fullscreenizeHotkeyModCtrl.Checked && !chk_fullscreenizeHotkeyModShift.Checked )
 			{
@@ -139,23 +139,23 @@ namespace Fullscreenizer
 			}
 		}
 
-		void cb_fullscreenizeHotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
+		private void cb_fullscreenizeHotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
 		{
 			_config.FullscreenizeKeyFlags = (Keys)cb_fullscreenizeHotkeyKey.SelectedItem;
-			if (_config.FullscreenizeHotkeyActive)
+			if( _config.FullscreenizeHotkeyActive )
 			{
 				enableHotkey();
 			}
 		}
 
-		private void chk_lockCursorEnableHotkey_Click(object sender, EventArgs e)
+		private void chk_lockCursorEnableHotkey_CheckedChanged(object sender, EventArgs e)
 		{
 			// Flip the hotkey.
-			chk_lockCursorEnableHotkey.Checked = !chk_lockCursorEnableHotkey.Checked;
+			gb_lockCursorHotkey.Enabled = chk_lockCursorEnableHotkey.Checked;
 			// Update the config.
 			_config.LockCursorHotkeyActive = chk_lockCursorEnableHotkey.Checked;
 			// Enable or disable based on status.
-			if (chk_lockCursorEnableHotkey.Checked)
+			if( chk_lockCursorEnableHotkey.Checked )
 			{
 				enableHotkey();
 			}
@@ -167,14 +167,14 @@ namespace Fullscreenizer
 
 		private void chk_lockCursorHotkeyModCtrl_Click(object sender, EventArgs e)
 		{
-			if (!chk_lockCursorHotkeyModShift.Checked && !chk_lockCursorHotkeyModAlt.Checked)
+			if( !chk_lockCursorHotkeyModShift.Checked && !chk_lockCursorHotkeyModAlt.Checked )
 			{
 				return;
 			}
 
 			chk_lockCursorHotkeyModCtrl.Checked = !chk_lockCursorHotkeyModCtrl.Checked;
 			updateModifierFlags();
-			if (_config.LockCursorHotkeyActive)
+			if( _config.LockCursorHotkeyActive )
 			{
 				enableHotkey();
 			}
@@ -182,14 +182,14 @@ namespace Fullscreenizer
 
 		private void chk_lockCursorHotkeyModShift_Click(object sender, EventArgs e)
 		{
-			if (!chk_lockCursorHotkeyModCtrl.Checked && !chk_lockCursorHotkeyModAlt.Checked)
+			if( !chk_lockCursorHotkeyModCtrl.Checked && !chk_lockCursorHotkeyModAlt.Checked )
 			{
 				return;
 			}
 
 			chk_lockCursorHotkeyModShift.Checked = !chk_lockCursorHotkeyModShift.Checked;
 			updateModifierFlags();
-			if (_config.LockCursorHotkeyActive)
+			if( _config.LockCursorHotkeyActive )
 			{
 				enableHotkey();
 			}
@@ -197,14 +197,14 @@ namespace Fullscreenizer
 
 		private void chk_lockCursorHotkeyModAlt_Click(object sender, EventArgs e)
 		{
-			if (!chk_lockCursorHotkeyModCtrl.Checked && !chk_lockCursorHotkeyModShift.Checked)
+			if( !chk_lockCursorHotkeyModCtrl.Checked && !chk_lockCursorHotkeyModShift.Checked )
 			{
 				return;
 			}
 
 			chk_lockCursorHotkeyModAlt.Checked = !chk_lockCursorHotkeyModAlt.Checked;
 			updateModifierFlags();
-			if (_config.LockCursorHotkeyActive)
+			if( _config.LockCursorHotkeyActive )
 			{
 				enableHotkey();
 			}
@@ -219,7 +219,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void btn_fullscreenizeApp_Click(object sender, EventArgs e)
+		private void btn_fullscreenizeApp_Click(object sender, EventArgs e)
 		{
 			if( lv_apps.SelectedItems.Count == 0 )
 			{
@@ -230,7 +230,7 @@ namespace Fullscreenizer
 			fullscreenizeWindow((IntPtr)item.Tag);
 		}
 
-		void btn_removeApp_Click(object sender, EventArgs e)
+		private void btn_removeApp_Click(object sender, EventArgs e)
 		{
 			GC.Collect();
 			if( lv_apps.SelectedItems.Count == 0 )
@@ -246,7 +246,7 @@ namespace Fullscreenizer
 			updateListView();
 		}
 
-		void btn_showAllApps_Click(object sender, EventArgs e)
+		private void btn_showAllApps_Click(object sender, EventArgs e)
 		{
 			AllApps frm = new AllApps(_config);
 			frm.ShowDialog(this);
@@ -257,23 +257,23 @@ namespace Fullscreenizer
 			}
 		}
 
-		void _windowUpdateTimer_Tick(object sender, EventArgs e)
+		private void _windowUpdateTimer_Tick(object sender, EventArgs e)
 		{
 			refreshApps();
 			updateListView();
 		}
 
-		void _canFullscreenizeTimer_Tick(object sender, EventArgs e)
+		private void _canFullscreenizeTimer_Tick(object sender, EventArgs e)
 		{
 			_canFullscreenize = true;
 		}
 
-		void chk_scaleToFit_CheckedChanged(object sender, EventArgs e)
+		private void chk_scaleToFit_CheckedChanged(object sender, EventArgs e)
 		{
 			_config.ScaleWindow = chk_scaleToFit.Checked;
 		}
 
-		void chk_moveWindow_CheckedChanged(object sender, EventArgs e)
+		private void chk_moveWindow_CheckedChanged(object sender, EventArgs e)
 		{
 			_config.MoveWindow = chk_moveWindow.Checked;
 		}
@@ -283,12 +283,12 @@ namespace Fullscreenizer
 			_config.LockCursor = chk_lockCursor.Checked;
 		}
 
-		void chk_minimizeToTray_CheckedChanged(object sender, EventArgs e)
+		private void chk_minimizeToTray_CheckedChanged(object sender, EventArgs e)
 		{
 			_config.MinimizeToTray = chk_minimizeToTray.Checked;
 		}
 
-		void lbl_website_Click(object sender, EventArgs e)
+		private void lbl_website_Click(object sender, EventArgs e)
 		{
 			System.Diagnostics.Process.Start("https://github.com/KasumiL5x/Fullscreenizer");
 		}
@@ -305,7 +305,7 @@ namespace Fullscreenizer
 			Close();
 		}
 
-		void processConfig()
+		private void processConfig()
 		{
 			// Read the config file, and if there's an error parsing it, warn the user and exit.
 			// This is favorable as it doesn't mean the user loses their config even it if fails.
@@ -325,20 +325,16 @@ namespace Fullscreenizer
 
 			// Read the key bit flag and set the comboboxes as required.
 			cb_fullscreenizeHotkeyKey.SelectedItem = _config.FullscreenizeKeyFlags;
-			cb_lockCursorHotkeyKey.SelectedItem = _config.LockCursorKeyFlags;
+			cb_lockCursorHotkeyKey.SelectedItem    = _config.LockCursorKeyFlags;
 
 			// Read the active state of the hotkey and create the hotkey if required.
-			if ( _config.FullscreenizeHotkeyActive )
+			if( _config.FullscreenizeHotkeyActive || _config.LockCursorHotkeyActive )
 			{
-				chk_fullscreenizeEnableHotkey.Checked = true;
 				enableHotkey();
 			}
 
-			if (_config.FullscreenizeHotkeyActive)
-			{
-				chk_lockCursorEnableHotkey.Checked = true;
-				enableHotkey();
-			}
+			chk_fullscreenizeEnableHotkey.Checked = _config.FullscreenizeHotkeyActive;
+			chk_lockCursorEnableHotkey.Checked    = _config.LockCursorHotkeyActive;
 
 			// Read the options.
 			chk_scaleToFit.Checked     = _config.ScaleWindow;
@@ -347,7 +343,7 @@ namespace Fullscreenizer
 			chk_minimizeToTray.Checked = _config.MinimizeToTray;
 		}
 
-		void buildKeysList()
+		private void buildKeysList()
 		{
 			List<Keys> keyDict = new List<Keys>
 			{
@@ -410,7 +406,7 @@ namespace Fullscreenizer
 			cb_lockCursorHotkeyKey.DataSource = new BindingSource(keyDict, null);
 		}
 
-		void updateModifierFlags()
+		private void updateModifierFlags()
 		{
 			_config.FullscreenizeModifierFlags = Modifier.None;
 			if( chk_fullscreenizeHotkeyModCtrl.Checked )
@@ -441,7 +437,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void hotkeyPressed( object sender, KeyEventArgs e )
+		private void hotkeyPressed( object sender, KeyEventArgs e )
 		{
 			// Append the currently held modifiers bit flag if any of the considered keys are pressed.
 			if( e.KeyCode == Keys.LControlKey || e.KeyCode == Keys.RControlKey )
@@ -477,7 +473,7 @@ namespace Fullscreenizer
 			bool altOk = (careAboutAlt && altPressed) || (!careAboutAlt);
 
 			IntPtr foregroundWindow = Win32.getForegroundWindow();
-			if ( foregroundWindow == IntPtr.Zero )
+			if( foregroundWindow == IntPtr.Zero )
 			{
 				return;
 			}
@@ -505,7 +501,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void hotkeyReleased( object sender, KeyEventArgs e )
+		private void hotkeyReleased( object sender, KeyEventArgs e )
 		{
 			// Not the modifiers if they were released.
 			if( e.KeyCode == Keys.LControlKey || e.KeyCode == Keys.RControlKey )
@@ -527,7 +523,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void enableHotkey()
+		private void enableHotkey()
 		{
 			_hook.hook();
 			_hook.removeAllKeys();
@@ -552,18 +548,18 @@ namespace Fullscreenizer
 			{
 				_hook.addKey(_config.FullscreenizeKeyFlags);
 			}
-			if ( _config.LockCursorHotkeyActive )
+			if( _config.LockCursorHotkeyActive )
 			{
 				_hook.addKey(_config.LockCursorKeyFlags);
 			}
-	}
+		}
 
-	void disableHotkey()
+		private void disableHotkey()
 		{
 			_hook.unhook(); // Doesn't remove keys; just disables.
 		}
 
-		void refreshApps()
+		private void refreshApps()
 		{
 			List<IntPtr> visibleWindows = Win32.getVisibleWindows(true);
 			foreach( IntPtr hwnd in visibleWindows )
@@ -616,7 +612,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void updateListView()
+		private void updateListView()
 		{
 			lv_apps.BeginUpdate();
 			
@@ -659,7 +655,7 @@ namespace Fullscreenizer
 			lv_apps.EndUpdate();
 		}
 
-		void rebuildImageList()
+		private void rebuildImageList()
 		{
 			_windowImages.Images.Clear();
 			foreach( ListViewItem item in lv_apps.Items )
@@ -674,7 +670,7 @@ namespace Fullscreenizer
 			}
 		}
 
-		void fullscreenizeWindow( IntPtr hwnd )
+		private void fullscreenizeWindow( IntPtr hwnd )
 		{
 			if( !_canFullscreenize )
 			{
@@ -757,7 +753,7 @@ namespace Fullscreenizer
 
 		private void notifyIcon_MouseClick(object sender, MouseEventArgs e)
 		{
-			if (e.Button == MouseButtons.Left)
+			if( e.Button == MouseButtons.Left )
 			{
 				Show();
 				WindowState = FormWindowState.Normal;

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -207,6 +207,11 @@ namespace Fullscreenizer
 			_config.MoveWindow = chk_moveWindow.Checked;
 		}
 
+		private void chk_lockCursor_CheckedChanged(object sender, EventArgs e)
+		{
+			_config.LockCursor = chk_lockCursor.Checked;
+		}
+
 		void chk_minimizeToTray_CheckedChanged(object sender, EventArgs e)
 		{
 			_config.MinimizeToTray = chk_minimizeToTray.Checked;
@@ -257,6 +262,7 @@ namespace Fullscreenizer
 			// Read the options.
 			chk_scaleToFit.Checked     = _config.ScaleWindow;
 			chk_moveWindow.Checked     = _config.MoveWindow;
+			chk_lockCursor.Checked     = _config.LockCursor;
 			chk_minimizeToTray.Checked = _config.MinimizeToTray;
 		}
 
@@ -634,5 +640,5 @@ namespace Fullscreenizer
 				notifyIcon.Visible = false;
 			}
 		}
-	}
+    }
 }

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -282,6 +282,19 @@ namespace Fullscreenizer
 			System.Diagnostics.Process.Start("https://github.com/KasumiL5x/Fullscreenizer");
 		}
 
+		private void lv_apps_DoubleClick(object sender, EventArgs e)
+		{
+			btn_removeApp.PerformClick();
+		}
+
+		private void notifyIcon_MouseClick(object sender, MouseEventArgs e)
+		{
+			if (e.Button == MouseButtons.Left)
+			{
+				toolStripMenuItemShow_Click(null, null);
+			}
+		}
+
 		private void toolStripMenuItemShow_Click(object sender, EventArgs e)
 		{
 			Show();
@@ -775,14 +788,6 @@ namespace Fullscreenizer
 			else
 			{
 				Cursor.Clip = _defaultCursorClip;
-			}
-		}
-
-		private void notifyIcon_MouseClick(object sender, MouseEventArgs e)
-		{
-			if( e.Button == MouseButtons.Left )
-			{
-				toolStripMenuItemShow_Click(null, null);
 			}
 		}
 	}

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -544,7 +544,19 @@ namespace Fullscreenizer
 
 		private void disableHotkey()
 		{
-			_hook.unhook(); // Doesn't remove keys; just disables.
+			if( !_config.FullscreenizeHotkeyActive )
+			{
+				_hook.removeKey(_config.FullscreenizeKeyFlags);
+			}
+			if( !_config.LockCursorHotkeyActive )
+			{
+				_hook.removeKey(_config.LockCursorKeyFlags);
+			}
+
+			if( !_config.FullscreenizeHotkeyActive && !_config.LockCursorHotkeyActive )
+			{
+				_hook.unhook(); // Doesn't remove keys; just disables.
+			}
 		}
 
 		private void refreshApps()

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -77,74 +77,145 @@ namespace Fullscreenizer
 			}
 		}
 
-		void chk_hotkeyModCtrl_Click(object sender, EventArgs e)
-		{
-			if( !chk_hotkeyModShift.Checked && !chk_hotkeyModAlt.Checked )
-			{
-				return;
-			}
-
-			chk_hotkeyModCtrl.Checked = !chk_hotkeyModCtrl.Checked;
-			updateModifierFlags();
-			if( _config.HotkeyActive )
-			{
-				enableHotkey();
-			}
-		}
-
-		void chk_hotkeyModShift_Click(object sender, EventArgs e)
-		{
-			if( !chk_hotkeyModCtrl.Checked && !chk_hotkeyModAlt.Checked )
-			{
-				return;
-			}
-
-			chk_hotkeyModShift.Checked = !chk_hotkeyModShift.Checked;
-			updateModifierFlags();
-			if( _config.HotkeyActive )
-			{
-				enableHotkey();
-			}
-		}
-
-		void chk_hotkeyModAlt_Click(object sender, EventArgs e)
-		{
-			if( !chk_hotkeyModCtrl.Checked && !chk_hotkeyModShift.Checked )
-			{
-				return;
-			}
-
-			chk_hotkeyModAlt.Checked = !chk_hotkeyModAlt.Checked;
-			updateModifierFlags();
-			if( _config.HotkeyActive )
-			{
-				enableHotkey();
-			}
-		}
-
-		void cb_hotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
-		{
-			_config.KeyFlags = (Keys)cb_hotkeyKey.SelectedItem;
-			if( _config.HotkeyActive )
-			{
-				enableHotkey();
-			}
-		}
-
-		void chk_enableHotkey_Click(object sender, EventArgs e)
+		void chk_fullscreenizeEnableHotkey_Click(object sender, EventArgs e)
 		{
 			// Flip the hotkey.
-			chk_enableHotkey.Checked = !chk_enableHotkey.Checked;
+			chk_fullscreenizeEnableHotkey.Checked = !chk_fullscreenizeEnableHotkey.Checked;
 			// Update the config.
-			_config.HotkeyActive = chk_enableHotkey.Checked;
+			_config.FullscreenizeHotkeyActive = chk_fullscreenizeEnableHotkey.Checked;
 			// Enable or disable based on status.
-			if( chk_enableHotkey.Checked )
+			if (chk_fullscreenizeEnableHotkey.Checked)
 			{
 				enableHotkey();
 			}
 			else
 			{
 				disableHotkey();
+			}
+		}
+
+		void chk_fullscreenizeHotkeyModCtrl_Click(object sender, EventArgs e)
+		{
+			if( !chk_fullscreenizeHotkeyModShift.Checked && !chk_fullscreenizeHotkeyModAlt.Checked )
+			{
+				return;
+			}
+
+			chk_fullscreenizeHotkeyModCtrl.Checked = !chk_fullscreenizeHotkeyModCtrl.Checked;
+			updateModifierFlags();
+			if( _config.FullscreenizeHotkeyActive )
+			{
+				enableHotkey();
+			}
+		}
+
+		void chk_fullscreenizeHotkeyModShift_Click(object sender, EventArgs e)
+		{
+			if( !chk_fullscreenizeHotkeyModCtrl.Checked && !chk_fullscreenizeHotkeyModAlt.Checked )
+			{
+				return;
+			}
+
+			chk_fullscreenizeHotkeyModShift.Checked = !chk_fullscreenizeHotkeyModShift.Checked;
+			updateModifierFlags();
+			if( _config.FullscreenizeHotkeyActive )
+			{
+				enableHotkey();
+			}
+		}
+
+		void chk_fullscreenizeHotkeyModAlt_Click(object sender, EventArgs e)
+		{
+			if( !chk_fullscreenizeHotkeyModCtrl.Checked && !chk_fullscreenizeHotkeyModShift.Checked )
+			{
+				return;
+			}
+
+			chk_fullscreenizeHotkeyModAlt.Checked = !chk_fullscreenizeHotkeyModAlt.Checked;
+			updateModifierFlags();
+			if( _config.FullscreenizeHotkeyActive )
+			{
+				enableHotkey();
+			}
+		}
+
+		void cb_fullscreenizeHotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
+		{
+			_config.FullscreenizeKeyFlags = (Keys)cb_fullscreenizeHotkeyKey.SelectedItem;
+			if (_config.FullscreenizeHotkeyActive)
+			{
+				enableHotkey();
+			}
+		}
+
+		private void chk_lockCursorEnableHotkey_Click(object sender, EventArgs e)
+		{
+			// Flip the hotkey.
+			chk_lockCursorEnableHotkey.Checked = !chk_lockCursorEnableHotkey.Checked;
+			// Update the config.
+			_config.LockCursorHotkeyActive = chk_lockCursorEnableHotkey.Checked;
+			// Enable or disable based on status.
+			if (chk_lockCursorEnableHotkey.Checked)
+			{
+				enableHotkey();
+			}
+			else
+			{
+				disableHotkey();
+			}
+		}
+
+		private void chk_lockCursorHotkeyModCtrl_Click(object sender, EventArgs e)
+		{
+			if (!chk_lockCursorHotkeyModShift.Checked && !chk_lockCursorHotkeyModAlt.Checked)
+			{
+				return;
+			}
+
+			chk_lockCursorHotkeyModCtrl.Checked = !chk_lockCursorHotkeyModCtrl.Checked;
+			updateModifierFlags();
+			if (_config.LockCursorHotkeyActive)
+			{
+				enableHotkey();
+			}
+		}
+
+		private void chk_lockCursorHotkeyModShift_Click(object sender, EventArgs e)
+		{
+			if (!chk_lockCursorHotkeyModCtrl.Checked && !chk_lockCursorHotkeyModAlt.Checked)
+			{
+				return;
+			}
+
+			chk_lockCursorHotkeyModShift.Checked = !chk_lockCursorHotkeyModShift.Checked;
+			updateModifierFlags();
+			if (_config.LockCursorHotkeyActive)
+			{
+				enableHotkey();
+			}
+		}
+
+		private void chk_lockCursorHotkeyModAlt_Click(object sender, EventArgs e)
+		{
+			if (!chk_lockCursorHotkeyModCtrl.Checked && !chk_lockCursorHotkeyModShift.Checked)
+			{
+				return;
+			}
+
+			chk_lockCursorHotkeyModAlt.Checked = !chk_lockCursorHotkeyModAlt.Checked;
+			updateModifierFlags();
+			if (_config.LockCursorHotkeyActive)
+			{
+				enableHotkey();
+			}
+		}
+
+		private void cb_lockCursorHotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
+		{
+			_config.LockCursorKeyFlags = (Keys)cb_fullscreenizeHotkeyKey.SelectedItem;
+			if( _config.LockCursorHotkeyActive )
+			{
+				enableHotkey();
 			}
 		}
 
@@ -245,17 +316,27 @@ namespace Fullscreenizer
 			}
 
 			// Read the modifier bit flag and enable checkboxes as required.
-			chk_hotkeyModCtrl.Checked  = ((_config.ModifierFlags & Modifier.Ctrl) != 0);
-			chk_hotkeyModShift.Checked = ((_config.ModifierFlags & Modifier.Shift) != 0);
-			chk_hotkeyModAlt.Checked   = ((_config.ModifierFlags & Modifier.Alt) != 0);
+			chk_fullscreenizeHotkeyModCtrl.Checked  = ((_config.FullscreenizeModifierFlags & Modifier.Ctrl) != 0);
+			chk_fullscreenizeHotkeyModShift.Checked = ((_config.FullscreenizeModifierFlags & Modifier.Shift) != 0);
+			chk_fullscreenizeHotkeyModAlt.Checked   = ((_config.FullscreenizeModifierFlags & Modifier.Alt) != 0);
+			chk_lockCursorHotkeyModCtrl.Checked     = ((_config.LockCursorModifierFlags & Modifier.Ctrl) != 0);
+			chk_lockCursorHotkeyModShift.Checked    = ((_config.LockCursorModifierFlags & Modifier.Shift) != 0);
+			chk_lockCursorHotkeyModAlt.Checked      = ((_config.LockCursorModifierFlags & Modifier.Alt) != 0);
 
-			// Read the key bit flag and set the combobox as required.
-			cb_hotkeyKey.SelectedItem = _config.KeyFlags;
+			// Read the key bit flag and set the comboboxes as required.
+			cb_fullscreenizeHotkeyKey.SelectedItem = _config.FullscreenizeKeyFlags;
+			cb_lockCursorHotkeyKey.SelectedItem = _config.LockCursorKeyFlags;
 
 			// Read the active state of the hotkey and create the hotkey if required.
-			if( _config.HotkeyActive )
+			if ( _config.FullscreenizeHotkeyActive )
 			{
-				chk_enableHotkey.Checked = true;
+				chk_fullscreenizeEnableHotkey.Checked = true;
+				enableHotkey();
+			}
+
+			if (_config.FullscreenizeHotkeyActive)
+			{
+				chk_lockCursorEnableHotkey.Checked = true;
 				enableHotkey();
 			}
 
@@ -323,23 +404,38 @@ namespace Fullscreenizer
 			keyDict.Add(Keys.End);
 			keyDict.Add(Keys.PageUp);
 			keyDict.Add(Keys.PageDown);
-			cb_hotkeyKey.DataSource = new BindingSource(keyDict, null);
+			cb_fullscreenizeHotkeyKey.DataSource = new BindingSource(keyDict, null);
+			cb_lockCursorHotkeyKey.DataSource = new BindingSource(keyDict, null);
 		}
 
 		void updateModifierFlags()
 		{
-			_config.ModifierFlags = Modifier.None;
-			if( chk_hotkeyModCtrl.Checked )
+			_config.FullscreenizeModifierFlags = Modifier.None;
+			if( chk_fullscreenizeHotkeyModCtrl.Checked )
 			{
-				_config.ModifierFlags |= Modifier.Ctrl;
+				_config.FullscreenizeModifierFlags |= Modifier.Ctrl;
 			}
-			if( chk_hotkeyModShift.Checked )
+			if( chk_fullscreenizeHotkeyModShift.Checked )
 			{
-				_config.ModifierFlags |= Modifier.Shift;
+				_config.FullscreenizeModifierFlags |= Modifier.Shift;
 			}
-			if( chk_hotkeyModAlt.Checked )
+			if( chk_fullscreenizeHotkeyModAlt.Checked )
 			{
-				_config.ModifierFlags |= Modifier.Alt;
+				_config.FullscreenizeModifierFlags |= Modifier.Alt;
+			}
+
+			_config.LockCursorModifierFlags = Modifier.None;
+			if( chk_lockCursorHotkeyModCtrl.Checked )
+			{
+				_config.LockCursorModifierFlags |= Modifier.Ctrl;
+			}
+			if( chk_lockCursorHotkeyModShift.Checked )
+			{
+				_config.LockCursorModifierFlags |= Modifier.Shift;
+			}
+			if( chk_lockCursorHotkeyModAlt.Checked )
+			{
+				_config.LockCursorModifierFlags |= Modifier.Alt;
 			}
 		}
 
@@ -358,16 +454,16 @@ namespace Fullscreenizer
 			{
 				_currHeldModifier |= Modifier.Alt;
 			}
-			else if( e.KeyCode == _config.KeyFlags )
+			else if( e.KeyCode == _config.FullscreenizeKeyFlags || e.KeyCode == _config.LockCursorKeyFlags )
 			{
 				// Also for the key, too.
 				_currHeldKey = e.KeyCode;
 			}
 
 			// Do we care about the modifiers?
-			bool careAboutCtrl = (_config.ModifierFlags & Modifier.Ctrl) != 0;
-			bool careAboutShift = (_config.ModifierFlags & Modifier.Shift) != 0;
-			bool careAboutAlt = (_config.ModifierFlags & Modifier.Alt) != 0;
+			bool careAboutCtrl = (_config.FullscreenizeModifierFlags & Modifier.Ctrl) != 0 || (_config.LockCursorModifierFlags & Modifier.Ctrl) != 0;
+			bool careAboutShift = (_config.FullscreenizeModifierFlags & Modifier.Shift) != 0 || (_config.LockCursorModifierFlags & Modifier.Shift) != 0;
+			bool careAboutAlt = (_config.FullscreenizeModifierFlags & Modifier.Alt) != 0 || (_config.LockCursorModifierFlags & Modifier.Alt) != 0;
 			// The actual currently held values.
 			bool ctrlPressed = (_currHeldModifier & Modifier.Ctrl) != 0;
 			bool shiftPressed = (_currHeldModifier & Modifier.Shift) != 0;
@@ -379,7 +475,7 @@ namespace Fullscreenizer
 			bool altOk = (careAboutAlt && altPressed) || (!careAboutAlt);
 
 			// If all are OK and the held key matches out desired key...
-			if( ctrlOk && shiftOk && altOk && (_currHeldKey == _config.KeyFlags) )
+			if( ctrlOk && shiftOk && altOk && (_currHeldKey == _config.FullscreenizeKeyFlags) )
 			{
 				IntPtr foregroundWindow = Win32.getForegroundWindow();
 				if( foregroundWindow == IntPtr.Zero )
@@ -406,7 +502,7 @@ namespace Fullscreenizer
 			{
 				_currHeldModifier = _currHeldModifier & ~Modifier.Alt;
 			}
-			else if( e.KeyCode == _config.KeyFlags )
+			else if( e.KeyCode == _config.FullscreenizeKeyFlags )
 			{
 				// Same for the keycode.
 				_currHeldKey = _currHeldKey & ~e.KeyCode;
@@ -418,26 +514,33 @@ namespace Fullscreenizer
 			_hook.hook();
 			_hook.removeAllKeys();
 
-			if( (_config.ModifierFlags & Modifier.Ctrl) != 0 )
+			if( (_config.FullscreenizeModifierFlags & Modifier.Ctrl) != 0 || (_config.LockCursorModifierFlags & Modifier.Ctrl) != 0 )
 			{
 				_hook.addKey(Keys.LControlKey);
 				_hook.addKey(Keys.RControlKey);
 			}
-			if( (_config.ModifierFlags & Modifier.Shift) != 0 )
+			if( (_config.FullscreenizeModifierFlags & Modifier.Shift) != 0 || (_config.LockCursorModifierFlags & Modifier.Shift) != 0 )
 			{
 				_hook.addKey(Keys.LShiftKey);
 				_hook.addKey(Keys.RShiftKey);
 			}
-			if( (_config.ModifierFlags & Modifier.Alt) != 0 )
+			if( (_config.FullscreenizeModifierFlags & Modifier.Alt) != 0 || (_config.LockCursorModifierFlags & Modifier.Alt) != 0 )
 			{
 				_hook.addKey(Keys.LMenu);
 				_hook.addKey(Keys.RMenu);
 			}
 
-			_hook.addKey(_config.KeyFlags);
-		}
+			if( _config.FullscreenizeHotkeyActive )
+			{
+				_hook.addKey(_config.FullscreenizeKeyFlags);
+			}
+			if ( _config.LockCursorHotkeyActive )
+			{
+				_hook.addKey(_config.LockCursorKeyFlags);
+			}
+	}
 
-		void disableHotkey()
+	void disableHotkey()
 		{
 			_hook.unhook(); // Doesn't remove keys; just disables.
 		}
@@ -567,8 +670,6 @@ namespace Fullscreenizer
 
 			AppState state = _windowHandles[hwnd];
 
-
-
 			bool isFullscreen = Win32.isWindowFullscreen(hwnd);
 			bool isBorderless = Win32.isWindowBorderlessStyle(hwnd);
 
@@ -640,5 +741,5 @@ namespace Fullscreenizer
 				notifyIcon.Visible = false;
 			}
 		}
-    }
+	}
 }

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -16,6 +16,7 @@ namespace Fullscreenizer
 
 		Config _config = new Config();
 		KeyboardHook _hook = new KeyboardHook();
+		List<object> _keyDict;
 		Modifier _currHeldModifier = Modifier.None; // Used to check if the user is pressing the correct modifiers.
 		Keys _currHeldKey = Keys.None; // Used to check if the user is pressing the correct key.
 
@@ -43,7 +44,8 @@ namespace Fullscreenizer
 			// Add callbacks to the keyboard hook.
 			_hook.KeyDown += new KeyEventHandler(hotkeyPressed);
 			_hook.KeyUp += new KeyEventHandler(hotkeyReleased);
-			// Build a list of keys for the hotkey key combobox.
+
+			// Build a list of keys for the hotkey key comboboxes.
 			buildKeysList();
 
 			// Parse the config file.
@@ -104,10 +106,7 @@ namespace Fullscreenizer
 
 			chk_fullscreenizeHotkeyModCtrl.Checked = !chk_fullscreenizeHotkeyModCtrl.Checked;
 			updateModifierFlags();
-			if( _config.FullscreenizeHotkeyActive )
-			{
-				enableHotkey();
-			}
+			enableHotkey();
 		}
 
 		private void chk_fullscreenizeHotkeyModShift_Click(object sender, EventArgs e)
@@ -119,10 +118,7 @@ namespace Fullscreenizer
 
 			chk_fullscreenizeHotkeyModShift.Checked = !chk_fullscreenizeHotkeyModShift.Checked;
 			updateModifierFlags();
-			if( _config.FullscreenizeHotkeyActive )
-			{
-				enableHotkey();
-			}
+			enableHotkey();
 		}
 
 		private void chk_fullscreenizeHotkeyModAlt_Click(object sender, EventArgs e)
@@ -134,19 +130,18 @@ namespace Fullscreenizer
 
 			chk_fullscreenizeHotkeyModAlt.Checked = !chk_fullscreenizeHotkeyModAlt.Checked;
 			updateModifierFlags();
-			if( _config.FullscreenizeHotkeyActive )
-			{
-				enableHotkey();
-			}
+			enableHotkey();
 		}
 
 		private void cb_fullscreenizeHotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
 		{
 			_config.FullscreenizeKeyFlags = (Keys)cb_fullscreenizeHotkeyKey.SelectedItem;
-			if( _config.FullscreenizeHotkeyActive )
-			{
-				enableHotkey();
-			}
+
+			// Make sure the fullscreenize key isn't in the lock cursor combobox
+			cb_lockCursorHotkeyKey.Items.Clear();
+			cb_lockCursorHotkeyKey.Items.AddRange(_keyDict.ToArray());
+			cb_lockCursorHotkeyKey.Items.Remove(_config.FullscreenizeKeyFlags);
+			cb_lockCursorHotkeyKey.SelectedItem = _config.LockCursorKeyFlags;
 		}
 
 		private void chk_lockCursorEnableHotkey_CheckedChanged(object sender, EventArgs e)
@@ -175,10 +170,7 @@ namespace Fullscreenizer
 
 			chk_lockCursorHotkeyModCtrl.Checked = !chk_lockCursorHotkeyModCtrl.Checked;
 			updateModifierFlags();
-			if( _config.LockCursorHotkeyActive )
-			{
-				enableHotkey();
-			}
+			enableHotkey();
 		}
 
 		private void chk_lockCursorHotkeyModShift_Click(object sender, EventArgs e)
@@ -190,10 +182,7 @@ namespace Fullscreenizer
 
 			chk_lockCursorHotkeyModShift.Checked = !chk_lockCursorHotkeyModShift.Checked;
 			updateModifierFlags();
-			if( _config.LockCursorHotkeyActive )
-			{
-				enableHotkey();
-			}
+			enableHotkey();
 		}
 
 		private void chk_lockCursorHotkeyModAlt_Click(object sender, EventArgs e)
@@ -205,19 +194,18 @@ namespace Fullscreenizer
 
 			chk_lockCursorHotkeyModAlt.Checked = !chk_lockCursorHotkeyModAlt.Checked;
 			updateModifierFlags();
-			if( _config.LockCursorHotkeyActive )
-			{
-				enableHotkey();
-			}
+			enableHotkey();
 		}
 
 		private void cb_lockCursorHotkeyKey_SelectionChangeCommitted(object sender, EventArgs e)
 		{
 			_config.LockCursorKeyFlags = (Keys)cb_lockCursorHotkeyKey.SelectedItem;
-			if( _config.LockCursorHotkeyActive )
-			{
-				enableHotkey();
-			}
+
+			// Make sure the lock cursor key isn't in the fullscreenize combobox
+			cb_fullscreenizeHotkeyKey.Items.Clear();
+			cb_fullscreenizeHotkeyKey.Items.AddRange(_keyDict.ToArray());
+			cb_fullscreenizeHotkeyKey.Items.Remove(_config.LockCursorKeyFlags);
+			cb_fullscreenizeHotkeyKey.SelectedItem = _config.FullscreenizeKeyFlags;
 		}
 
 		private void btn_fullscreenizeApp_Click(object sender, EventArgs e)
@@ -327,6 +315,8 @@ namespace Fullscreenizer
 			// Read the key bit flag and set the comboboxes as required.
 			cb_fullscreenizeHotkeyKey.SelectedItem = _config.FullscreenizeKeyFlags;
 			cb_lockCursorHotkeyKey.SelectedItem    = _config.LockCursorKeyFlags;
+			cb_fullscreenizeHotkeyKey.Items.Remove(_config.LockCursorKeyFlags);
+			cb_lockCursorHotkeyKey.Items.Remove(_config.FullscreenizeKeyFlags);
 
 			// Read the active state of the hotkeys and create the hotkeys if required.
 			if( _config.FullscreenizeHotkeyActive || _config.LockCursorHotkeyActive )
@@ -346,7 +336,7 @@ namespace Fullscreenizer
 
 		private void buildKeysList()
 		{
-			List<Keys> keyDict = new List<Keys>
+			_keyDict = new List<object>
 			{
 				Keys.A,
 				Keys.B,
@@ -403,8 +393,9 @@ namespace Fullscreenizer
 				Keys.PageUp,
 				Keys.PageDown
 			};
-			cb_fullscreenizeHotkeyKey.DataSource = new BindingSource(keyDict, null);
-			cb_lockCursorHotkeyKey.DataSource = new BindingSource(keyDict, null);
+
+			cb_fullscreenizeHotkeyKey.Items.AddRange(_keyDict.ToArray());
+			cb_lockCursorHotkeyKey.Items.AddRange(_keyDict.ToArray());
 		}
 
 		private void updateModifierFlags()
@@ -764,9 +755,7 @@ namespace Fullscreenizer
 		{
 			if( e.Button == MouseButtons.Left )
 			{
-				Show();
-				WindowState = FormWindowState.Normal;
-				notifyIcon.Visible = false;
+				toolStripMenuItemShow_Click(null, null);
 			}
 		}
 	}

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -682,8 +682,6 @@ namespace Fullscreenizer
 				return;
 			}
 
-			AppState state = _windowHandles[hwnd];
-
 			bool isFullscreen = Win32.isWindowFullscreen(hwnd);
 			bool isBorderless = Win32.isWindowBorderlessStyle(hwnd);
 
@@ -693,6 +691,8 @@ namespace Fullscreenizer
 			{
 				return;
 			}
+
+			AppState state = _windowHandles[hwnd];
 
 			// Used to check for fullscreen here, too, but now we allow for no scaling, so don't check it.
 			if( isBorderless )
@@ -745,6 +745,13 @@ namespace Fullscreenizer
 				{
 					lockCursor(hwnd);
 				}
+			}
+
+			// Some apps take time to become borderless and may stop responding to input so we make sure to clear held keys
+			if( _hook.isKeyDown((Keys)_config.FullscreenizeKeyFlags) )
+			{
+				_currHeldModifier = Modifier.None;
+				_currHeldKey = Keys.None;
 			}
 
 			_canFullscreenize = false;

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -485,18 +485,7 @@ namespace Fullscreenizer
 
 			if( lockCursorCtrlOk && lockCursorShiftOk && lockCursorAltOk && (_currHeldKey == _config.LockCursorKeyFlags) )
 			{
-				Win32.getWindowRect(foregroundWindow, out int x, out int y, out int width, out int height );
-
-				// Lock the cursor to the window bounds
-				if( Cursor.Clip.Equals(_defaultCursorClip) )
-				{
-					Cursor.Clip = new Rectangle(x, y, width, height);
-				}
-				// The cursor was already locked to the window bounds, unlock it
-				else
-				{
-					Cursor.Clip = Rectangle.Empty;
-				}
+				lockCursor(foregroundWindow);
 			}
 		}
 
@@ -708,7 +697,7 @@ namespace Fullscreenizer
 				Win32.setWindowPos(hwnd, state.initialX, state.initialY, state.initialWidth, state.initialHeight, Win32.SetWindowPosFlags.SWP_FRAMECHANGED);
 
 				// Unlock the cursor
-				Cursor.Clip = Rectangle.Empty;
+				Cursor.Clip = _defaultCursorClip;
 			}
 			else
 			{
@@ -742,13 +731,32 @@ namespace Fullscreenizer
 
 				if( chk_lockCursor.Checked )
 				{
-					// Lock the cursor to the window bounds
-					Win32.getWindowRect(hwnd, out int x, out int y, out int width, out int height);
-					Cursor.Clip = new Rectangle(x, y, width, height);
+					lockCursor(hwnd);
 				}
 			}
 
 			_canFullscreenize = false;
+		}
+
+		private void lockCursor( IntPtr hwnd )
+		{
+			if(!_windowHandles.ContainsKey(hwnd))
+			{
+				return;
+			}
+
+			Win32.getWindowRect(hwnd, out int x, out int y, out int width, out int height);
+
+			// Lock the cursor to the window bounds
+			if(Cursor.Clip.Equals(_defaultCursorClip))
+			{
+				Cursor.Clip = new Rectangle(x, y, width, height);
+			}
+			// The cursor was already locked to the window bounds, unlock it
+			else
+			{
+				Cursor.Clip = _defaultCursorClip;
+			}
 		}
 
 		private void notifyIcon_MouseClick(object sender, MouseEventArgs e)

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -349,61 +349,63 @@ namespace Fullscreenizer
 
 		void buildKeysList()
 		{
-			List<Keys> keyDict = new List<Keys>();
-			keyDict.Add(Keys.A);
-			keyDict.Add(Keys.B);
-			keyDict.Add(Keys.C);
-			keyDict.Add(Keys.D);
-			keyDict.Add(Keys.E);
-			keyDict.Add(Keys.F);
-			keyDict.Add(Keys.G);
-			keyDict.Add(Keys.H);
-			keyDict.Add(Keys.I);
-			keyDict.Add(Keys.J);
-			keyDict.Add(Keys.K);
-			keyDict.Add(Keys.L);
-			keyDict.Add(Keys.M);
-			keyDict.Add(Keys.N);
-			keyDict.Add(Keys.O);
-			keyDict.Add(Keys.P);
-			keyDict.Add(Keys.Q);
-			keyDict.Add(Keys.R);
-			keyDict.Add(Keys.S);
-			keyDict.Add(Keys.T);
-			keyDict.Add(Keys.U);
-			keyDict.Add(Keys.V);
-			keyDict.Add(Keys.W);
-			keyDict.Add(Keys.X);
-			keyDict.Add(Keys.Y);
-			keyDict.Add(Keys.Z);
-			keyDict.Add(Keys.D1);
-			keyDict.Add(Keys.D2);
-			keyDict.Add(Keys.D3);
-			keyDict.Add(Keys.D4);
-			keyDict.Add(Keys.D5);
-			keyDict.Add(Keys.D6);
-			keyDict.Add(Keys.D7);
-			keyDict.Add(Keys.D8);
-			keyDict.Add(Keys.D9);
-			keyDict.Add(Keys.D0);
-			keyDict.Add(Keys.F1);
-			keyDict.Add(Keys.F2);
-			keyDict.Add(Keys.F3);
-			keyDict.Add(Keys.F4);
-			keyDict.Add(Keys.F5);
-			keyDict.Add(Keys.F6);
-			keyDict.Add(Keys.F7);
-			keyDict.Add(Keys.F8);
-			keyDict.Add(Keys.F9);
-			keyDict.Add(Keys.F10);
-			keyDict.Add(Keys.F11);
-			keyDict.Add(Keys.F12);
-			keyDict.Add(Keys.Insert);
-			keyDict.Add(Keys.Delete);
-			keyDict.Add(Keys.Home);
-			keyDict.Add(Keys.End);
-			keyDict.Add(Keys.PageUp);
-			keyDict.Add(Keys.PageDown);
+			List<Keys> keyDict = new List<Keys>
+			{
+				Keys.A,
+				Keys.B,
+				Keys.C,
+				Keys.D,
+				Keys.E,
+				Keys.F,
+				Keys.G,
+				Keys.H,
+				Keys.I,
+				Keys.J,
+				Keys.K,
+				Keys.L,
+				Keys.M,
+				Keys.N,
+				Keys.O,
+				Keys.P,
+				Keys.Q,
+				Keys.R,
+				Keys.S,
+				Keys.T,
+				Keys.U,
+				Keys.V,
+				Keys.W,
+				Keys.X,
+				Keys.Y,
+				Keys.Z,
+				Keys.D1,
+				Keys.D2,
+				Keys.D3,
+				Keys.D4,
+				Keys.D5,
+				Keys.D6,
+				Keys.D7,
+				Keys.D8,
+				Keys.D9,
+				Keys.D0,
+				Keys.F1,
+				Keys.F2,
+				Keys.F3,
+				Keys.F4,
+				Keys.F5,
+				Keys.F6,
+				Keys.F7,
+				Keys.F8,
+				Keys.F9,
+				Keys.F10,
+				Keys.F11,
+				Keys.F12,
+				Keys.Insert,
+				Keys.Delete,
+				Keys.Home,
+				Keys.End,
+				Keys.PageUp,
+				Keys.PageDown
+			};
 			cb_fullscreenizeHotkeyKey.DataSource = new BindingSource(keyDict, null);
 			cb_lockCursorHotkeyKey.DataSource = new BindingSource(keyDict, null);
 		}
@@ -722,11 +724,7 @@ namespace Fullscreenizer
 				Win32.getWindowRect(hwnd, out state.initialX, out state.initialY, out state.initialWidth, out state.initialHeight);
 
 				// Get the size and position of the monitor the window is open on.
-				int monitorX = 0;
-				int monitorY = 0;
-				int monitorWidth = 0;
-				int monitorHeight = 0;
-				Win32.getWindowMonitorSize(hwnd, out monitorX, out monitorY, out monitorWidth, out monitorHeight);
+				Win32.getWindowMonitorSize(hwnd, out int monitorX, out int monitorY, out int monitorWidth, out int monitorHeight);
 				// Make the window borderless.
 				Win32.makeWindowBorderless(hwnd);
 

--- a/Fullscreenizer/Fullscreenizer.cs
+++ b/Fullscreenizer/Fullscreenizer.cs
@@ -227,9 +227,11 @@ namespace Fullscreenizer
 				return;
 			}
 
-			ListViewItem item = lv_apps.SelectedItems[0];
-			AppState state = _windowHandles[(IntPtr)item.Tag];
-			_config.Classes.Remove(state.className);
+			foreach (ListViewItem item in lv_apps.SelectedItems)
+			{
+				AppState state = _windowHandles[(IntPtr)item.Tag];
+				_config.Classes.Remove(state.className);
+			}
 
 			refreshApps();
 			updateListView();
@@ -289,7 +291,7 @@ namespace Fullscreenizer
 
 		private void notifyIcon_MouseClick(object sender, MouseEventArgs e)
 		{
-			if (e.Button == MouseButtons.Left)
+			if( e.Button == MouseButtons.Left )
 			{
 				toolStripMenuItemShow_Click(null, null);
 			}

--- a/Fullscreenizer/Win32.cs
+++ b/Fullscreenizer/Win32.cs
@@ -124,8 +124,6 @@ namespace Fullscreenizer
 		[DllImport("user32.dll")]
 		static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
 
-
-
 		public static bool enumDesktopWindows( EnumDesktopWindowsDelegate proc )
 		{
 			return EnumDesktopWindows(IntPtr.Zero, proc, IntPtr.Zero);
@@ -292,22 +290,13 @@ namespace Fullscreenizer
 
 		public static bool isWindowFullscreen( IntPtr hwnd )
 		{
-			int monitorX = 0;
-			int monitorY = 0;
-			int monitorWidth = 0;
-			int monitorHeight = 0;
-			getWindowMonitorSize(hwnd, out monitorX, out monitorY, out monitorWidth, out monitorHeight);
-
-			int windowX = 0;
-			int windowY = 0;
-			int windowWidth = 0;
-			int windowHeight = 0;
-			getWindowRect(hwnd, out windowX, out windowY, out windowWidth, out windowHeight);
+			getWindowMonitorSize(hwnd, out int monitorX, out int monitorY, out int monitorWidth, out int monitorHeight);
+			getWindowRect(hwnd, out int windowX, out int windowY, out int windowWidth, out int windowHeight);
 
 			return ((monitorX == windowX) &&
-						  (monitorY == windowY) &&
-						  (monitorWidth == windowWidth) &&
-						  (monitorHeight == windowHeight));
+						(monitorY == windowY) &&
+						(monitorWidth == windowWidth) &&
+						(monitorHeight == windowHeight));
 		}
 	}
 }


### PR DESCRIPTION
After your release from the other day, I realized Fullscreenizer wasn't locking the cursor to the window unlike other borderless programs, so I added support for it.

There's a new "Lock cursor" checkbox that will lock the cursor when fullscreenizing and a new hotkey to lock/unlock the cursor whether the window is borderless or not. The hotkey works without enabling the "Lock cursor" checkbox. The cursor is automatically unlocked by the OS when alt-tabbing or pressing the Windows key, so there's no risk .

Both hotkeys can't be the same (I had to change the keyDict list item type to object to be able work with the combo box's ObjectCollection without casting the whole list).

I didn't go to the full extent of locking the cursor after tabbing back in, that'd require additional work (adding more win32 functions and listening to WM_SETFOCUS/WM_KILLFOCUS messages) for such little value.

Groupboxes are now disabled when unchecking the hotkey checkboxes so there's no need to check if the hotkey is active anymore when changing the modifiers/keys.

I also fixed a bug present in the stable release where a window made borderless by Fullscreenizer couldn't be restored to its original state if it was at (0, 0) initially.

Aside from that, I did some minor code refactoring such as removing unnecessary variables and making sure the code I added in my previous pull request matches your code style.

Here's what it'll look like:
![image](https://user-images.githubusercontent.com/3614449/113456266-bd1ed480-93da-11eb-9f48-2970062823cc.png)